### PR TITLE
refactor(lib): isTauri() 유틸리티를 lib/tauri.ts로 중앙화

### DIFF
--- a/src/hooks/useWindowResize.ts
+++ b/src/hooks/useWindowResize.ts
@@ -3,9 +3,9 @@
 
 import { useEffect, RefObject } from "react";
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+import { isTauri } from "../lib/tauri";
 
 const WIDGET_WIDTH = 380;
-const isTauri = () => Boolean((window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__);
 
 export function useWindowResize(containerRef: RefObject<HTMLElement | null>) {
   useEffect(() => {

--- a/src/hooks/useWindowSync.ts
+++ b/src/hooks/useWindowSync.ts
@@ -4,8 +4,7 @@
 import { useEffect, useRef } from "react";
 import { getCurrentWindow, PhysicalPosition } from "@tauri-apps/api/window";
 import type { WidgetSettings } from "../types";
-
-const isTauri = () => Boolean((window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__);
+import { isTauri } from "../lib/tauri";
 
 interface UseWindowSyncOptions {
   settings: WidgetSettings;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -3,6 +3,9 @@
 
 import { invoke as tauriInvoke } from "@tauri-apps/api/core";
 
+export const isTauri = () =>
+  Boolean((window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__);
+
 export async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   try {
     return await tauriInvoke<T>(cmd, args);


### PR DESCRIPTION
## Summary
- `useWindowResize.ts`와 `useWindowSync.ts`에 동일하게 중복 정의된 `isTauri()` 함수를 `lib/tauri.ts`로 추출
- 두 훅은 이제 로컬 정의 대신 `import { isTauri } from "../lib/tauri"` 사용

## Changes
- `src/lib/tauri.ts`: `isTauri()` 유틸리티 export 추가
- `src/hooks/useWindowResize.ts`: 로컬 `isTauri` 정의 제거 → import로 교체
- `src/hooks/useWindowSync.ts`: 로컬 `isTauri` 정의 제거 → import로 교체

## 선택 근거
`lib/tauri.ts`는 이미 Tauri 백엔드 통신(invoke wrapper)을 중앙화하는 역할을 하고 있음. 환경 감지 유틸리티도 같은 모듈에 두는 것이 일관성에 맞고 DRY 원칙을 따름. 동작 변경 없음 (동일한 구현을 추출).

---
_자율 개발 에이전트가 생성한 PR_