### PR TITLE
feat(projects): ProjectCard에 마지막 커밋 메시지 표시

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -195,6 +195,19 @@ export function ProjectCard({ project, onUpdate, onDelete, pat }: ProjectCardPro
           </div>
         )}
       </div>
+      {/* Last commit message */}
+      {!repoMsg && project.githubData && (
+        <div
+          title={project.githubData.lastCommitMsg}
+          style={{
+            paddingLeft: 14, marginTop: 2, width: "100%",
+            ...mono, fontSize: fontSizes.mini, color: colors.textPhantom,
+            overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          }}
+        >
+          {project.githubData.lastCommitMsg}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `githubData.lastCommitMsg`가 API에서 이미 fetch되지만 UI에 표시되지 않던 갭 해소
- GitHub 배지 행(시간, issues, PRs, CI) 바로 아래 단일 줄로 표시
- CSS `text-overflow: ellipsis` + `title` 속성으로 긴 커밋 메시지 자연스럽게 처리

## Changes
- `src/components/ProjectCard.tsx` — lastCommitMsg 표시 div 추가 (1파일)
  - `!repoMsg && project.githubData` 기존 조건과 동일한 조건 사용 (일관성)
  - `width: "100%"` + `overflow: hidden` + `text-overflow: ellipsis`로 CSS 잘림
  - `title` 속성에 전체 커밋 메시지 (hover tooltip)

## 선택 근거
lastCommitMsg는 GitHubData 타입에 non-optional로 정의되어 있고 이미 fetch 중이나
렌더 코드 어디에도 사용되지 않는 명확한 데이터 표시 갭. Project 현황 파악 목표에 직접 기여.

---
_자율 개발 에이전트가 생성한 PR_