### PR TITLE
feat(streaks): Streaks 섹션 라벨에 오늘 완료 습관 배지 추가

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,10 +172,10 @@ fn default_data() -> WidgetData {
             },
         ],
         habits: vec![
-            Habit { name: "푸시업".into(), streak: 0, icon: "💪".into(), last_checked: None },
-            Habit { name: "풀업".into(), streak: 0, icon: "🏋️".into(), last_checked: None },
-            Habit { name: "폰 사용↓".into(), streak: 0, icon: "📵".into(), last_checked: None },
-            Habit { name: "포모도로".into(), streak: 0, icon: "🍅".into(), last_checked: None },
+            Habit { id: None, name: "푸시업".into(), streak: 0, icon: "💪".into(), last_checked: None },
+            Habit { id: None, name: "풀업".into(), streak: 0, icon: "🏋️".into(), last_checked: None },
+            Habit { id: None, name: "폰 사용↓".into(), streak: 0, icon: "📵".into(), last_checked: None },
+            Habit { id: None, name: "포모도로".into(), streak: 0, icon: "🍅".into(), last_checked: None },
         ],
         quotes: vec![
             "Design so it cannot fail fatally, then execute.".into(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,6 +183,12 @@ export default function App() {
   const theme = THEMES[settings.theme] ?? THEMES.void;
   const themeAccent = theme.accent;
 
+  // Derived: habits done today — same render-time date pattern as pomodoroSessionsToday above.
+  // Brief (<1 min) badge/button mismatch at midnight is acceptable; matching existing project pattern.
+  const habitsArr = data.habits ?? [];
+  const habitsDoneToday = habitsArr.filter(h => h.lastChecked === new Date().toLocaleDateString("sv")).length;
+  const habitsBadge = habitsArr.length > 0 ? `${habitsDoneToday}/${habitsArr.length}` : undefined;
+
   return (
     <div
       ref={containerRef}
@@ -219,7 +225,7 @@ export default function App() {
           />
         )}
 
-        <SectionLabel accent={themeAccent} collapsed={collapsed.includes("streaks")} onToggle={() => toggleSection("streaks")}>Streaks</SectionLabel>
+        <SectionLabel accent={themeAccent} collapsed={collapsed.includes("streaks")} onToggle={() => toggleSection("streaks")} badge={habitsBadge}>Streaks</SectionLabel>
         {!collapsed.includes("streaks") && (
           <HabitStreak habits={data.habits} onUpdate={updateHabit} onHabitsChange={updateHabits} accent={themeAccent} />
         )}

--- a/src/components/SectionLabel.tsx
+++ b/src/components/SectionLabel.tsx
@@ -8,9 +8,10 @@ interface SectionLabelProps {
   collapsed?: boolean;
   onToggle?: () => void;
   accent?: string;
+  badge?: string; // optional summary shown after label, e.g. "3/4"
 }
 
-export function SectionLabel({ children, collapsed = false, onToggle, accent }: SectionLabelProps) {
+export function SectionLabel({ children, collapsed = false, onToggle, accent, badge }: SectionLabelProps) {
   return (
     <div
       onClick={onToggle}
@@ -24,6 +25,15 @@ export function SectionLabel({ children, collapsed = false, onToggle, accent }: 
       }}
     >
       {children}
+      {badge && (
+        <span style={{
+          fontSize: fontSizes.mini, fontWeight: 400,
+          color: accent ? `${accent}66` : colors.textPhantom,
+          letterSpacing: 0, textTransform: "none",
+        }}>
+          {badge}
+        </span>
+      )}
       {onToggle && (
         <span style={{
           fontSize: fontSizes.mini,


### PR DESCRIPTION
## Summary
- SectionLabel에 `badge?: string` prop 추가 — 섹션 라벨 텍스트 옆에 요약 정보 표시 가능
- Streaks 섹션 라벨에 `X/N` 배지 표시 — 오늘 체크한 습관 수 / 전체 습관 수
- 섹션이 접혀 있어도 한눈에 완료 현황 파악 가능

## Changes
- `src/components/SectionLabel.tsx`: `badge?: string` prop 추가, 라벨과 chevron 사이에 렌더
- `src/App.tsx`: `habitsArr.filter(lastChecked === today)` 계산 + Streaks SectionLabel에 전달
- `src-tauri/src/lib.rs`: 기존 미커밋 변경 포함 — `default_data()` Habit에 `id: None` 필드 추가

## 선택 근거
"위젯 내 모든 데이터 인라인 편집 가능 + Project 현황 파악" 목표 기여.
최근 30 커밋에 없는 작업, 외부 의존성 없음, 2파일 변경으로 scope 내 완결.

---
_자율 개발 에이전트가 생성한 PR_