### PR TITLE
feat(projects): Project에 외부 URL 필드 추가 — 인라인 편집 + 클릭 열기

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,8 @@ pub struct Project {
     pub notes: Option<String>,
     #[serde(rename = "isFocus", default, skip_serializing_if = "Option::is_none")]
     pub is_focus: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -179,6 +181,7 @@ fn default_data() -> WidgetData {
                 deadline: None,
                 notes: None,
                 is_focus: None,
+                url: None,
             },
             Project {
                 id: 2,
@@ -194,6 +197,7 @@ fn default_data() -> WidgetData {
                 deadline: None,
                 notes: None,
                 is_focus: None,
+                url: None,
             },
             Project {
                 id: 3,
@@ -209,6 +213,7 @@ fn default_data() -> WidgetData {
                 deadline: None,
                 notes: None,
                 is_focus: None,
+                url: None,
             },
         ],
         habits: vec![
@@ -305,6 +310,9 @@ fn load_data() -> WidgetData {
         }
         if project.notes.as_deref() == Some("") {
             project.notes = None;
+        }
+        if project.url.as_deref() == Some("") {
+            project.url = None;
         }
         // is_focus: false is equivalent to absent (absent = not focused)
         if project.is_focus == Some(false) {

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -243,6 +243,48 @@ export function ProjectCard({ project, onUpdate, onDelete, pat }: ProjectCardPro
           </button>
         )}
       </div>
+      {/* URL — external link (website, docs, design); ⇱ opens in browser when set */}
+      <div style={{ display: "flex", alignItems: "center", gap: 6, paddingLeft: 14, marginTop: 2 }}>
+        <InlineEdit
+          value={project.url ?? ""}
+          placeholder="+ URL"
+          onSave={v => onUpdate?.({ url: v.trim() || undefined })}
+          style={{ ...mono, fontSize: fontSizes.mini, color: project.url ? colors.textSubtle : colors.textPhantom, flex: 1 }}
+          inputStyle={{ ...mono, fontSize: fontSizes.mini }}
+        />
+        {project.url && (
+          <>
+            {(() => {
+              const isValidUrl = /^https?:\/\//i.test(project.url);
+              return (
+                <button
+                  onClick={() => { if (isValidUrl) openUrl(project.url!); }}
+                  disabled={!isValidUrl}
+                  title={isValidUrl ? `열기: ${project.url}` : "http:// 또는 https:// 로 시작해야 합니다"}
+                  style={{
+                    background: "transparent", border: "none",
+                    cursor: isValidUrl ? "pointer" : "default",
+                    color: isValidUrl ? colors.textPhantom : colors.textLabel,
+                    fontSize: fontSizes.mini, padding: "0 2px", lineHeight: 1,
+                  }}
+                >
+                  ⇱
+                </button>
+              );
+            })()}
+            <button
+              onClick={() => onUpdate?.({ url: undefined })}
+              title="URL 삭제"
+              style={{
+                background: "transparent", border: "none", cursor: "pointer",
+                color: colors.textPhantom, fontSize: fontSizes.mini, padding: "0 2px", lineHeight: 1,
+              }}
+            >
+              ✕
+            </button>
+          </>
+        )}
+      </div>
       {/* Deadline — inline editable; faint placeholder when unset; urgency color when set */}
       <div style={{ display: "flex", alignItems: "center", gap: 6, paddingLeft: 14, marginTop: 2 }}>
         {project.deadline ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface Project {
   deadline?: string;      // YYYY-MM-DD, project target completion date
   notes?: string;         // freeform project notes: context, blockers, next steps
   isFocus?: boolean;      // marks project as today's focus/priority; absent = not focused
+  url?: string;           // external project URL (website, docs, design link); absent = not set
 }
 
 export interface Habit {


### PR DESCRIPTION
## Summary

- `Project.url?: string` 필드 추가 — 프로젝트 외부 링크(웹사이트, 문서, 디자인) 저장
- InlineEdit `+ URL` placeholder로 인라인 입력, `⇱` 버튼으로 브라우저 열기
- http/https scheme 검증 — 유효하지 않은 URL은 ⇱ 버튼이 dim 처리 (silent no-op 방지)
- `✕` 버튼으로 URL 삭제, empty/whitespace trim 후 `undefined` 저장

## Changes

- `src/types.ts` — `url?: string` 필드 추가
- `src-tauri/src/lib.rs` — `url: Option<String>` 필드 + sanitize(empty→None) + default_data 3개 `url: None`
- `src/components/ProjectCard.tsx` — URL 행(notes 아래, deadline 위) 추가

## 선택 근거

Project.url 필드 부재 → 프로젝트 웹사이트/문서/디자인 링크 빠른 접근 불가. "Project 현황 파악 및 관리 편의 기능" 목표 부합. 최근 30 커밋 + agent-log 비중복.

---
_자율 개발 에이전트가 생성한 PR_