### PR TITLE
feat(direction): 의도 이력 패널 달성률 요약 추가 — X/Y 달성 · N%

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -767,6 +767,8 @@ export default function App() {
             // Past intentions: filter out today, take newest 6, reverse to newest-first.
             // Computed once and shared between toggle button visibility and history panel.
             const pastIntentions = (data.intentionHistory ?? []).filter(e => e.date !== todayStr).slice(-6).reverse();
+            // Intention history success rate — same metric as W/M/Q/Y goal history panels, shown when expanded.
+            const intentionHistoryRate = calcGoalSuccessRate(pastIntentions);
             // Goal success rates — computed once, shared between each history panel and the toggle button.
             const weekGoalRate = calcGoalSuccessRate(data.weekGoalHistory ?? []);
             const monthGoalRate = calcGoalSuccessRate(data.monthGoalHistory ?? []);
@@ -1046,6 +1048,11 @@ export default function App() {
                     {/* Past intention history — up to 6 previous days, newest first */}
                     {showHistory && pastIntentions.length > 0 && (
                       <div style={{ padding: "0 14px 6px" }}>
+                        {intentionHistoryRate && (
+                          <div style={{ ...s.mono, fontSize: fontSizes.mini, color: colors.textPhantom, marginBottom: 3, opacity: 0.7 }}>
+                            {intentionHistoryRate.done}/{intentionHistoryRate.total} 달성 · {intentionHistoryRate.pct}%
+                          </div>
+                        )}
                         {pastIntentions.map(e => (
                           <div key={e.date} style={{ display: "flex", gap: 8, alignItems: "baseline", marginBottom: 3 }}>
                             <span style={{ ...s.mono, fontSize: fontSizes.mini, color: colors.textPhantom, flexShrink: 0, minWidth: 32 }}>{e.date.slice(5)}</span>


### PR DESCRIPTION
## Summary
- 의도(Intention) 이력 패널 상단에 `X/Y 달성 · N%` 달성률 요약 추가
- W/M/Q/Y 목표 이력 패널과 동일한 UI 패턴으로 일관성 확보

## Changes
- `src/App.tsx`: `calcGoalSuccessRate(pastIntentions)` 호출 → `intentionHistoryRate` 계산, 이력 패널 상단에 렌더링 (+7줄)
- 기존 `calcGoalSuccessRate` 재사용 (새 함수/인터페이스 없음) — `IntentionEntry`는 `GoalEntry`와 구조적으로 동일해 타입 캐스트 불필요

## 선택 근거
W/M/Q/Y 목표 이력 패널은 확장 시 `X/Y 달성 · N%` 요약을 보여주지만 의도 이력 패널에만 해당 요약이 없어 UI 일관성 갭 존재. 1파일 변경, self-contained, 기존 함수 재사용으로 코드 중복 없음.

---
_자율 개발 에이전트가 생성한 PR_