### PR TITLE
feat(pomodoro): calcTodaySessionCount + updatePomodoroHistory 순수 함수 추출 + 13개 테스트

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Handles data loading/saving, inline patch updates, and section reorder via sectionOrder field
 
 import { useState, useEffect, useCallback, useRef, CSSProperties, Fragment } from "react";
-import type { WidgetData, Habit, Project, SectionKey, GitHubData, PomodoroDay, IntentionEntry } from "./types";
+import type { WidgetData, Habit, Project, SectionKey, GitHubData, IntentionEntry } from "./types";
 import { colors, fonts, fontSizes, radius, shadows, THEMES, PROJECT_STATUS_COLORS } from "./theme";
 import { invoke, isTauri } from "./lib/tauri";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -19,6 +19,7 @@ import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQu
 import { calcGoalExpiry } from "./lib/goalExpiry";
 import { calcDirectionBadge } from "./lib/direction";
 import { calcProjectsBadge } from "./lib/projects";
+import { calcTodaySessionCount, updatePomodoroHistory } from "./lib/pomodoro";
 import { Clock } from "./components/Clock";
 import { DragBar } from "./components/DragBar";
 import { SectionLabel } from "./components/SectionLabel";
@@ -524,13 +525,8 @@ export default function App() {
 
   const handlePomodoroSession = useCallback((focusMins: number) => {
     const today = new Date().toLocaleDateString("sv"); // YYYY-MM-DD local date (sv = Swedish = ISO format)
-    const count = data.pomodoroSessionsDate === today ? (data.pomodoroSessions ?? 0) + 1 : 1;
-    // Upsert today's count into rolling history: remove old entry for today, append updated, sort, cap at 14.
-    // Sorted YYYY-MM-DD strings compare lexicographically = chronologically, matching checkHistory pattern.
-    const history: PomodoroDay[] = data.pomodoroHistory ?? [];
-    const newHistory = [...history.filter(d => d.date !== today), { date: today, count }]
-      .sort((a, b) => a.date.localeCompare(b.date))
-      .slice(-14);
+    const count = calcTodaySessionCount(data.pomodoroSessionsDate, data.pomodoroSessions, today);
+    const newHistory = updatePomodoroHistory(data.pomodoroHistory ?? [], today, count);
     // Credit session to the ★ focused project (if any) as a lifetime counter.
     const focusIdx = data.projects.findIndex(p => p.isFocus);
     const updatedProjects = focusIdx >= 0

--- a/src/lib/pomodoro.test.ts
+++ b/src/lib/pomodoro.test.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Unit tests for pomodoro pure helpers — calcLast14Days and calcSessionWeekTrend
-// ABOUTME: Covers date range derivation, prev-7/cur-7 session partitioning, and trend arrow logic
+// ABOUTME: Unit tests for pomodoro pure helpers — calcTodaySessionCount, updatePomodoroHistory, calcLast14Days, calcSessionWeekTrend
+// ABOUTME: Covers today-count reset/increment, 14-day history upsert, date range derivation, prev-7/cur-7 trend logic
 
 import { describe, it, expect } from "vitest";
-import { calcLast14Days, calcSessionWeekTrend } from "./pomodoro";
+import { calcLast14Days, calcSessionWeekTrend, calcTodaySessionCount, updatePomodoroHistory } from "./pomodoro";
 import type { PomodoroDay } from "../types";
 
 // Shared fixture: derived from calcLast14Days so partitioning assumptions stay consistent.
@@ -180,5 +180,108 @@ describe("calcSessionWeekTrend", () => {
     const result = calcSessionWeekTrend(history, LAST14)!;
     expect(result.cur7).toBe(2);
     expect(result.prev7).toBe(0);
+  });
+});
+
+describe("calcTodaySessionCount", () => {
+  const TODAY = "2026-03-15";
+
+  it("should return 1 when sessionDate is undefined (first session ever)", () => {
+    expect(calcTodaySessionCount(undefined, undefined, TODAY)).toBe(1);
+  });
+
+  it("should return 1 when sessionDate is a past date (new day, reset)", () => {
+    expect(calcTodaySessionCount("2026-03-14", 7, TODAY)).toBe(1);
+  });
+
+  it("should return 1 when sessionDate equals today but sessionCount is undefined", () => {
+    // Defensive: sessionDate matches but count absent — treat as first
+    expect(calcTodaySessionCount(TODAY, undefined, TODAY)).toBe(1);
+  });
+
+  it("should return 2 when sessionDate equals today and sessionCount is 1", () => {
+    expect(calcTodaySessionCount(TODAY, 1, TODAY)).toBe(2);
+  });
+
+  it("should return 6 when sessionDate equals today and sessionCount is 5", () => {
+    expect(calcTodaySessionCount(TODAY, 5, TODAY)).toBe(6);
+  });
+
+  it("should reset on any date mismatch, regardless of session count magnitude", () => {
+    expect(calcTodaySessionCount("2025-01-01", 999, TODAY)).toBe(1);
+  });
+});
+
+describe("updatePomodoroHistory", () => {
+  const TODAY = "2026-03-15";
+
+  it("should return a single-entry array when history is empty", () => {
+    const result = updatePomodoroHistory([], TODAY, 3);
+    expect(result).toEqual([{ date: TODAY, count: 3 }]);
+  });
+
+  it("should append today when today is not yet in history", () => {
+    const history: PomodoroDay[] = [{ date: "2026-03-14", count: 2 }];
+    const result = updatePomodoroHistory(history, TODAY, 5);
+    expect(result).toContainEqual({ date: TODAY, count: 5 });
+    expect(result).toContainEqual({ date: "2026-03-14", count: 2 });
+    expect(result).toHaveLength(2);
+  });
+
+  it("should replace today's existing entry with the new count", () => {
+    const history: PomodoroDay[] = [
+      { date: "2026-03-14", count: 2 },
+      { date: TODAY, count: 3 },
+    ];
+    const result = updatePomodoroHistory(history, TODAY, 5);
+    // Only one entry for today, with updated count
+    const todayEntries = result.filter(d => d.date === TODAY);
+    expect(todayEntries).toHaveLength(1);
+    expect(todayEntries[0].count).toBe(5);
+  });
+
+  it("should return entries sorted ascending by date", () => {
+    const history: PomodoroDay[] = [
+      { date: "2026-03-10", count: 1 },
+      { date: "2026-03-12", count: 2 },
+    ];
+    const result = updatePomodoroHistory(history, TODAY, 4);
+    expect(result[0].date).toBe("2026-03-10");
+    expect(result[1].date).toBe("2026-03-12");
+    expect(result[2].date).toBe(TODAY);
+  });
+
+  it("should cap at 14 entries when history is full and today is not in it", () => {
+    // Build 14 past entries — adding today makes 15, so oldest is dropped
+    const history: PomodoroDay[] = Array.from({ length: 14 }, (_, i) => ({
+      date: `2026-02-${String(i + 1).padStart(2, "0")}`,
+      count: i + 1,
+    }));
+    const result = updatePomodoroHistory(history, TODAY, 1);
+    expect(result).toHaveLength(14);
+    expect(result[result.length - 1].date).toBe(TODAY);
+    // Oldest entry (2026-02-01) should have been dropped
+    expect(result.some(d => d.date === "2026-02-01")).toBe(false);
+  });
+
+  it("should stay at 14 entries when history already has today and is at the cap", () => {
+    // 13 past entries + today = 14 in, replace today → still 14
+    const history: PomodoroDay[] = [
+      ...Array.from({ length: 13 }, (_, i) => ({
+        date: `2026-02-${String(i + 1).padStart(2, "0")}`,
+        count: i + 1,
+      })),
+      { date: TODAY, count: 2 },
+    ];
+    const result = updatePomodoroHistory(history, TODAY, 8);
+    expect(result).toHaveLength(14);
+    expect(result.find(d => d.date === TODAY)?.count).toBe(8);
+  });
+
+  it("should not mutate the original history array", () => {
+    const history: PomodoroDay[] = [{ date: "2026-03-14", count: 1 }];
+    const original = [...history];
+    updatePomodoroHistory(history, TODAY, 3);
+    expect(history).toEqual(original);
   });
 });

--- a/src/lib/pomodoro.ts
+++ b/src/lib/pomodoro.ts
@@ -1,7 +1,35 @@
 // ABOUTME: Pure helpers for pomodoro session statistics — no side effects
-// ABOUTME: Covers 14-day date range derivation and prev-7/cur-7 session trend calculation
+// ABOUTME: Covers today-count derivation, 14-day history upsert, date range, and week trend calculation
 
 import type { PomodoroDay } from "../types";
+
+// Returns the updated today-session count given the persisted state.
+// Resets to 1 when sessionDate differs from today (new day); increments by 1 when same day.
+// sessionDate: stored 'pomodoroSessionsDate' (YYYY-MM-DD or undefined)
+// sessionCount: stored 'pomodoroSessions' (integer or undefined)
+// today: current date as YYYY-MM-DD
+// Exported for unit testing; pure function with no side effects.
+export function calcTodaySessionCount(
+  sessionDate: string | undefined,
+  sessionCount: number | undefined,
+  today: string,
+): number {
+  return sessionDate === today ? (sessionCount ?? 0) + 1 : 1;
+}
+
+// Upserts today's session count into the rolling 14-day history.
+// Removes any existing entry for today, appends the new count, sorts chronologically, caps at 14.
+// Does not mutate the input history array.
+// Exported for unit testing; pure function with no side effects.
+export function updatePomodoroHistory(
+  history: PomodoroDay[],
+  today: string,
+  count: number,
+): PomodoroDay[] {
+  return [...history.filter(d => d.date !== today), { date: today, count }]
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .slice(-14);
+}
 
 // Returns the last 14 YYYY-MM-DD date strings (oldest → newest) anchored at todayStr.
 // Index 0 = 13 days ago; index 13 = today.


### PR DESCRIPTION
## Summary
- `handlePomodoroSession` 내 인라인 세션 카운트·이력 업데이트 로직을 `src/lib/pomodoro.ts`로 추출
- `calcTodaySessionCount`: 오늘 세션 카운트 계산 (날짜 변경 시 1로 리셋, 같은 날 증가)
- `updatePomodoroHistory`: 14일 롤링 히스토리 upsert (중복 제거, 정렬, cap-14)

## Changes
- `src/lib/pomodoro.ts` — 두 함수 추가 + ABOUTME 주석 업데이트
- `src/lib/pomodoro.test.ts` — 13개 단위 테스트 추가 (644 → 657)
- `src/App.tsx` — 추출된 함수 사용으로 교체, 미사용 `PomodoroDay` import 제거

## 선택 근거
진행 중인 순수 함수 추출 패턴 일관성 적용 — 핵심 포모도로 추적 로직이 컴포넌트 클로저에 묻혀 있어 회귀 탐지가 불가능했다. Reviewer: clean (critical/important 없음).

---
_자율 개발 에이전트가 생성한 PR_