### PR TITLE
refactor(habits): calcTargetStreakPct 순수 함수 추출 + 11개 테스트

### DIFF
--- a/src/components/HabitStreak.tsx
+++ b/src/components/HabitStreak.tsx
@@ -6,7 +6,7 @@ import type { Habit } from "../types";
 import { fonts, fontSizes, colors } from "../theme";
 import { InlineEdit } from "./InlineEdit";
 import { useEditMode } from "../hooks/useEditMode";
-import { calcHabitWeekStats, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo } from "../lib/habits";
+import { calcHabitWeekStats, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo, calcTargetStreakPct } from "../lib/habits";
 import { calcLastNDays } from "../lib/datePeriods";
 // Re-export the 4 helpers that moved from this file to lib/habits — preserves any existing imports.
 export { getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo };
@@ -387,10 +387,8 @@ export function HabitStreak({ habits, onUpdate, onHabitsChange, accent, onMilest
           const milestone = getMilestone(h.streak);
           const upcoming = getUpcomingMilestone(h.streak);
           const history = h.checkHistory ?? [];
-          // targetPct: progress toward targetStreak goal, clamped to 100%; undefined when no goal or streak is 0
-          const targetPct = (h.targetStreak ?? 0) > 0 && h.streak > 0
-            ? Math.min(100, Math.round(h.streak / h.targetStreak! * 100))
-            : undefined;
+          // targetPct: progress toward targetStreak goal; undefined when no goal or streak is 0 (see calcTargetStreakPct)
+          const targetPct = calcTargetStreakPct(h.streak, h.targetStreak);
           // Weekly stats: cur7/prev7 count + trend derived from last14Days partition (see calcHabitWeekStats).
           const { cur7: checkedCount7, prev7: prevWeekCount7, trend: weekTrend } = calcHabitWeekStats(h.checkHistory, last14Days);
           return (

--- a/src/lib/habits.test.ts
+++ b/src/lib/habits.test.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Unit tests for calcHabitsWeekRate, calcHabitWeekStats, calcHabitsBadge, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, and habitLastCheckDaysAgo pure helpers
-// ABOUTME: Validates average daily completion rate, per-habit weekly trend statistics, section badge formatting, check-in/undo patch generation, perfect-day streak, milestone badges, and completion tracking
+// ABOUTME: Unit tests for calcHabitsWeekRate, calcHabitWeekStats, calcHabitsBadge, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo, and calcTargetStreakPct pure helpers
+// ABOUTME: Validates average daily completion rate, per-habit weekly trend statistics, section badge formatting, check-in/undo patch generation, perfect-day streak, milestone badges, completion tracking, and target streak progress
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { calcHabitsWeekRate, calcHabitWeekStats, calcHabitsBadge, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo } from "./habits";
+import { calcHabitsWeekRate, calcHabitWeekStats, calcHabitsBadge, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo, calcTargetStreakPct } from "./habits";
 import type { Habit } from "../types";
 
 // Fixed 7-day window for deterministic tests (oldest → newest)
@@ -776,5 +776,51 @@ describe("habitLastCheckDaysAgo", () => {
   it("should return null for future lastCheck dates (clock skew or manual edit)", () => {
     // Future date produces negative days; days >= 2 is false, so null is returned safely
     expect(habitLastCheckDaysAgo(["2026-03-20"], TODAY_LCD)).toBeNull();
+  });
+});
+
+describe("calcTargetStreakPct", () => {
+  it("should return undefined when targetStreak is undefined (no goal set)", () => {
+    expect(calcTargetStreakPct(15, undefined)).toBeUndefined();
+  });
+
+  it("should return undefined when targetStreak is 0 (no goal — lib.rs sanitizes 0→None)", () => {
+    expect(calcTargetStreakPct(15, 0)).toBeUndefined();
+  });
+
+  it("should return undefined when streak is 0 (not started — no progress to display)", () => {
+    expect(calcTargetStreakPct(0, 30)).toBeUndefined();
+  });
+
+  it("should return 50 when streak is half of target (15/30)", () => {
+    expect(calcTargetStreakPct(15, 30)).toBe(50);
+  });
+
+  it("should return 100 when streak exactly equals target (goal achieved)", () => {
+    expect(calcTargetStreakPct(30, 30)).toBe(100);
+  });
+
+  it("should clamp to 100 when streak exceeds target (streak can temporarily exceed goal via manual edit)", () => {
+    expect(calcTargetStreakPct(35, 30)).toBe(100);
+  });
+
+  it("should return 3 for streak=1, target=30 (Math.round(1/30*100) = Math.round(3.333...) = 3)", () => {
+    expect(calcTargetStreakPct(1, 30)).toBe(3);
+  });
+
+  it("should return 97 for streak=29, target=30 (Math.round(29/30*100) = Math.round(96.666...) = 97)", () => {
+    expect(calcTargetStreakPct(29, 30)).toBe(97);
+  });
+
+  it("should return undefined when targetStreak is negative (invalid goal — same guard as 0)", () => {
+    expect(calcTargetStreakPct(15, -1)).toBeUndefined();
+  });
+
+  it("should return 100 for streak=1, target=1 (single-day goal met immediately)", () => {
+    expect(calcTargetStreakPct(1, 1)).toBe(100);
+  });
+
+  it("should return 100 for streak=7, target=7 (week goal exactly met)", () => {
+    expect(calcTargetStreakPct(7, 7)).toBe(100);
   });
 });

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -181,6 +181,16 @@ export function calcPerfectDayStreak(habits: Habit[], dayWindow: string[]): numb
   return streak;
 }
 
+// Returns percentage progress toward the user-defined target streak goal, clamped to [0, 100].
+// Returns undefined when: targetStreak is absent/0/negative (no valid goal) or streak is 0 or negative (not started).
+// Separates "no goal" from "goal at 0%" so callers can gate progress bar visibility cleanly.
+// Exported for unit testing; pure function with no side effects.
+export function calcTargetStreakPct(streak: number, targetStreak: number | undefined): number | undefined {
+  const target = targetStreak ?? 0;
+  if (target <= 0 || streak <= 0) return undefined;
+  return Math.min(100, Math.round(streak / target * 100));
+}
+
 // Returns weekly check statistics for a single habit, partitioned from a 14-day window.
 // last14Days: 14 YYYY-MM-DD strings ordered oldest→newest.
 //   Indices 0–6: previous week; indices 7–13: current week.


### PR DESCRIPTION
## Summary
- `HabitStreak.tsx`의 인라인 `targetPct` 계산을 `lib/habits.ts`의 `calcTargetStreakPct` 순수 함수로 추출
- 11개 단위 테스트 추가 (undefined 엣지케이스, 경계값, 클램프, 음수 입력)
- `target` 지역 변수로 non-null assertion(`!`) 제거 → 타입 안전한 구현

## Changes
- `lib/habits.ts`: `calcTargetStreakPct(streak, targetStreak)` 함수 추가 + 주석
- `lib/habits.test.ts`: import 업데이트 + 11개 테스트 (736 → 747)
- `HabitStreak.tsx`: 인라인 3줄 → `calcTargetStreakPct(h.streak, h.targetStreak)` 1줄

## 선택 근거
기존 리팩토링 패턴(inline → lib/ 추출 + 단위 테스트)과 일관성 유지. 테스트 없는 인라인 순수 로직 해소.

---
_자율 개발 에이전트가 생성한 PR_