### PR TITLE
feat(momentum): 연속 고점수 스트릭 + 7일 평균 배지

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -4,6 +4,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { fonts, fontSizes, colors, radius } from "../theme";
 import type { DailyScore } from "../lib/momentum";
+import { calcMomentumStreak, calcMomentumWeekAvg } from "../lib/momentum";
 import type { MomentumEntry } from "../types";
 
 // Returns the fraction of the calendar day elapsed (0.0 = midnight, 0.5 = noon, 1.0 = end of day).
@@ -87,6 +88,11 @@ export function Clock({ use12h = false, accent, onToggleFormat, dailyScore, mome
   }, [momentumHistory]);
   // Show sparkline only when there are ≥2 history entries (including today) so the trend is meaningful.
   const showSparkline = (momentumHistory?.length ?? 0) >= 2;
+  // Streak + weekly avg derived from history in a single memo; recalculates only when history changes
+  const { momentumStreak, momentumWeekAvg } = useMemo(() => ({
+    momentumStreak: calcMomentumStreak(momentumHistory ?? []),
+    momentumWeekAvg: calcMomentumWeekAvg(momentumHistory ?? []),
+  }), [momentumHistory]);
 
   return (
     <div style={{ marginBottom: 20 }}>
@@ -133,9 +139,23 @@ export function Clock({ use12h = false, accent, onToggleFormat, dailyScore, mome
           )}
         </div>
       </div>
-      {/* 7-day momentum sparkline — past 6 days as colored dots; shown when ≥2 history entries */}
+      {/* 7-day momentum sparkline — streak badge + avg + past 6 days as colored dots; shown when ≥2 history entries */}
       {showSparkline && (
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 3, marginTop: 5 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 4, marginTop: 5 }}>
+          <span
+            title={`7일 평균 모멘텀 ${momentumWeekAvg ?? 0}/100`}
+            style={{ ...mono, fontSize: fontSizes.mini, color: colors.textPhantom, opacity: 0.7, letterSpacing: 0.5, userSelect: "none" }}
+          >
+            {momentumWeekAvg ?? 0}
+          </span>
+          {momentumStreak >= 2 && (
+            <span
+              title={`${momentumStreak}일 연속 고점수 🔥`}
+              style={{ ...mono, fontSize: fontSizes.mini, color: accent ?? colors.statusActive, opacity: 0.75, userSelect: "none" }}
+            >
+              🔥{momentumStreak}
+            </span>
+          )}
           {sparklineDays.map((day, di) => {
             const entry = histMap.get(day);
             const daysAgo = 6 - di;

--- a/src/lib/momentum.test.ts
+++ b/src/lib/momentum.test.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Tests for calcDailyScore and updateMomentumHistory — score, tier, and history edge cases
-// ABOUTME: Covers no-activity baseline, full score, partial inputs, tier thresholds, and history upsert/cap
+// ABOUTME: Tests for momentum pure functions: calcDailyScore, updateMomentumHistory, calcMomentumStreak, calcMomentumWeekAvg
+// ABOUTME: Covers score computation, tier thresholds, history upsert/cap, consecutive streak with date gaps, and weekly average
 
 import { describe, it, expect } from "vitest";
-import { calcDailyScore, updateMomentumHistory } from "./momentum";
+import { calcDailyScore, updateMomentumHistory, calcMomentumStreak, calcMomentumWeekAvg } from "./momentum";
 
 describe("calcDailyScore", () => {
   it("returns score 0 and tier 'low' with no activity", () => {
@@ -279,5 +279,128 @@ describe("updateMomentumHistory", () => {
     const result = updateMomentumHistory([], "", 0, "low");
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({ date: "", score: 0, tier: "low" });
+  });
+});
+
+describe("calcMomentumStreak", () => {
+  it("returns 0 for empty history", () => {
+    expect(calcMomentumStreak([])).toBe(0);
+  });
+
+  it("returns 0 when last entry is not high tier", () => {
+    const history = [
+      { date: "2026-03-14", score: 80, tier: "high" as const },
+      { date: "2026-03-15", score: 45, tier: "mid" as const },
+    ];
+    expect(calcMomentumStreak(history)).toBe(0);
+  });
+
+  it("returns 0 when last entry is low tier", () => {
+    const history = [{ date: "2026-03-15", score: 20, tier: "low" as const }];
+    expect(calcMomentumStreak(history)).toBe(0);
+  });
+
+  it("returns 1 when only the last entry is high", () => {
+    const history = [
+      { date: "2026-03-14", score: 50, tier: "mid" as const },
+      { date: "2026-03-15", score: 80, tier: "high" as const },
+    ];
+    expect(calcMomentumStreak(history)).toBe(1);
+  });
+
+  it("returns 2 for two consecutive high entries at end", () => {
+    const history = [
+      { date: "2026-03-13", score: 30, tier: "low" as const },
+      { date: "2026-03-14", score: 78, tier: "high" as const },
+      { date: "2026-03-15", score: 90, tier: "high" as const },
+    ];
+    expect(calcMomentumStreak(history)).toBe(2);
+  });
+
+  it("returns full count when all entries are high", () => {
+    const history = [
+      { date: "2026-03-11", score: 76, tier: "high" as const },
+      { date: "2026-03-12", score: 82, tier: "high" as const },
+      { date: "2026-03-13", score: 91, tier: "high" as const },
+      { date: "2026-03-14", score: 77, tier: "high" as const },
+      { date: "2026-03-15", score: 88, tier: "high" as const },
+    ];
+    expect(calcMomentumStreak(history)).toBe(5);
+  });
+
+  it("stops counting when mid tier interrupts the streak from the end", () => {
+    const history = [
+      { date: "2026-03-12", score: 85, tier: "high" as const },
+      { date: "2026-03-13", score: 55, tier: "mid" as const },
+      { date: "2026-03-14", score: 80, tier: "high" as const },
+      { date: "2026-03-15", score: 78, tier: "high" as const },
+    ];
+    expect(calcMomentumStreak(history)).toBe(2);
+  });
+
+  it("single high entry returns 1", () => {
+    const history = [{ date: "2026-03-15", score: 88, tier: "high" as const }];
+    expect(calcMomentumStreak(history)).toBe(1);
+  });
+
+  it("returns 1 (not 2) when two high entries have a date gap between them", () => {
+    // Gap: 2026-03-10 → 2026-03-15 (5 days, not 1 day)
+    const history = [
+      { date: "2026-03-10", score: 80, tier: "high" as const },
+      { date: "2026-03-15", score: 85, tier: "high" as const },
+    ];
+    expect(calcMomentumStreak(history)).toBe(1);
+  });
+
+  it("streak stops at date gap even when all tiers are high", () => {
+    // Consecutive for last 3 entries but gap before them
+    const history = [
+      { date: "2026-03-10", score: 80, tier: "high" as const },
+      { date: "2026-03-13", score: 82, tier: "high" as const }, // gap: +3 days
+      { date: "2026-03-14", score: 85, tier: "high" as const },
+      { date: "2026-03-15", score: 88, tier: "high" as const },
+    ];
+    expect(calcMomentumStreak(history)).toBe(3);
+  });
+});
+
+describe("calcMomentumWeekAvg", () => {
+  it("returns null for empty history", () => {
+    expect(calcMomentumWeekAvg([])).toBeNull();
+  });
+
+  it("returns score rounded when single entry", () => {
+    const history = [{ date: "2026-03-15", score: 72, tier: "mid" as const }];
+    expect(calcMomentumWeekAvg(history)).toBe(72);
+  });
+
+  it("returns average of all entries", () => {
+    const history = [
+      { date: "2026-03-13", score: 80, tier: "high" as const },
+      { date: "2026-03-14", score: 60, tier: "mid" as const },
+      { date: "2026-03-15", score: 40, tier: "mid" as const },
+    ];
+    // (80 + 60 + 40) / 3 = 60
+    expect(calcMomentumWeekAvg(history)).toBe(60);
+  });
+
+  it("rounds to nearest integer", () => {
+    const history = [
+      { date: "2026-03-14", score: 70, tier: "mid" as const },
+      { date: "2026-03-15", score: 71, tier: "mid" as const },
+    ];
+    // (70 + 71) / 2 = 70.5 → rounds to 71
+    expect(calcMomentumWeekAvg(history)).toBe(71);
+  });
+
+  it("uses all 7 entries when history is full", () => {
+    const scores = [80, 70, 60, 75, 85, 90, 65];
+    const history = scores.map((score, i) => ({
+      date: `2026-03-${String(i + 9).padStart(2, "0")}`,
+      score,
+      tier: "mid" as const,
+    }));
+    const expected = Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+    expect(calcMomentumWeekAvg(history)).toBe(expected);
   });
 });

--- a/src/lib/momentum.ts
+++ b/src/lib/momentum.ts
@@ -1,5 +1,5 @@
 // ABOUTME: calcDailyScore — computes a 0-100 momentum score from today's habits, pomodoro, and intention
-// ABOUTME: updateMomentumHistory — upserts today's score into rolling 7-day history; pure function
+// ABOUTME: updateMomentumHistory, calcMomentumStreak, calcMomentumWeekAvg — history management and derived stats
 
 import type { MomentumEntry } from "../types";
 
@@ -89,4 +89,37 @@ export function updateMomentumHistory(
   }
   // Keep only the most recent MOMENTUM_HISTORY_CAP entries (newest last)
   return next.length > MOMENTUM_HISTORY_CAP ? next.slice(next.length - MOMENTUM_HISTORY_CAP) : next;
+}
+
+/**
+ * Returns the count of consecutive "high" tier entries with no date gaps ending at the most recent entry.
+ * "Consecutive" means both tier==="high" AND adjacent dates differ by exactly 1 calendar day.
+ * Returns 0 when: history is empty, the last entry is not "high", or date gaps exist.
+ */
+export function calcMomentumStreak(history: MomentumEntry[]): number {
+  if (history.length === 0) return 0;
+  if (history[history.length - 1].tier !== "high") return 0;
+  let count = 1;
+  for (let i = history.length - 1; i >= 1; i--) {
+    const prev = history[i - 1];
+    const curr = history[i];
+    if (prev.tier !== "high") break;
+    // Dates must be exactly 1 calendar day apart (no gaps allowed in a "consecutive" streak).
+    // UTC midnight avoids DST-related discrepancies on local timezone transitions.
+    const prevTs = new Date(prev.date + "T00:00:00Z").getTime();
+    const currTs = new Date(curr.date + "T00:00:00Z").getTime();
+    if (Math.round((currTs - prevTs) / 86400000) !== 1) break;
+    count++;
+  }
+  return count;
+}
+
+/**
+ * Returns the rounded average score across all entries in history.
+ * Returns null when history is empty.
+ */
+export function calcMomentumWeekAvg(history: MomentumEntry[]): number | null {
+  if (history.length === 0) return null;
+  const sum = history.reduce((acc, e) => acc + e.score, 0);
+  return Math.round(sum / history.length);
 }


### PR DESCRIPTION
## Summary
- `calcMomentumStreak`: 히스토리 끝에서 연속된 high-tier 일수 카운트 (날짜 1일 차이 + UTC 자정 기준으로 DST 안전)
- `calcMomentumWeekAvg`: 최근 7일 점수 평균(반올림)
- `Clock.tsx` 스파크라인 행에 `avg·숫자` + `🔥N` 배지 표시 (streak ≥2 때 활성)

## Changes
- `src/lib/momentum.ts`: 두 순수 함수 추가 + ABOUTME 업데이트
- `src/lib/momentum.test.ts`: 15개 테스트 추가 (날짜 갭 케이스 포함) + ABOUTME 업데이트
- `src/components/Clock.tsx`: 단일 useMemo로 streak + avg 계산, 스파크라인 행 UI

## 선택 근거
모멘텀 스파크라인(7일 점수 시각화)이 이미 있으나, '며칠 연속 고점수인지', '주간 평균이 얼마인지'는 미구현.
연속 유지 동기부여 루프를 완성해 유사 서비스 대비 차별화.

---
_자율 개발 에이전트가 생성한 PR_