### PR TITLE
feat(habits): calcHabitsWeekTrend — 주간 트렌드 ↑/↓/→ 배지 표시

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { useGitHubSync } from "./hooks/useGitHubSync";
 import { fetchRepoData } from "./lib/github";
 import { totalDaysInMonth, totalDaysInQuarter, totalDaysInYear, periodElapsedFraction, daysLeftInWeek, daysLeftInMonth, daysLeftInQuarter, daysLeftInYear, calcLastNDays } from "./lib/datePeriods";
 import { calcIntentionStreak, calcIntentionWeek, calcIntentionWeekTrend } from "./lib/intention";
-import { calcHabitsWeekRate, calcHabitsBadge, calcPerfectDayStreak } from "./lib/habits";
+import { calcHabitsWeekRate, calcHabitsWeekTrend, calcHabitsBadge, calcPerfectDayStreak } from "./lib/habits";
 import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQuarterGoalStreak, calcYearGoalStreak, calcGoalSuccessRate, calcLastNWeeks, calcWeekGoalHeatmap, calcLastNMonths, calcMonthGoalHeatmap, calcLastNQuarters, calcQuarterGoalHeatmap, calcLastNYears, calcYearGoalHeatmap } from "./lib/goalPeriods";
 import { calcGoalExpiry } from "./lib/goalExpiry";
 import { calcDirectionBadge } from "./lib/direction";
@@ -734,7 +734,8 @@ export default function App() {
   const quarterGoalStreak = calcQuarterGoalStreak(data.quarterGoal, data.quarterGoalDate, data.quarterGoalHistory ?? [], renderDate);
   const yearGoalStreak = calcYearGoalStreak(data.yearGoal, data.yearGoalDate, data.yearGoalHistory ?? [], renderDate);
   // last7Days: [6daysAgo, ..., yesterday, today] as YYYY-MM-DD strings (oldest→newest, HabitStreak.tsx convention).
-  // Single source shared by habitsWeekRate, weekPomodoroCount, and recentlyDoneCount.
+  // Single source shared by habitsWeekRate (cur-7), weekPomodoroCount, and recentlyDoneCount.
+  // habitsWeekTrend uses last14Days.slice(0,7) for the prev-7 window (see below).
   const last7Days = calcLastNDays(todayStr, 7);
   // intentionWeek: per-day set/done status for the last 7 days — pure function extracted to src/lib/intention.ts.
   // Note: updateIntention preserves history entries when the user clears today's intention
@@ -750,11 +751,15 @@ export default function App() {
   // habitsPerfectStreak: consecutive days all habits completed — same 14-day window as HabitStreak.tsx.
   const last14Days = calcLastNDays(todayStr, 14);
   const habitsPerfectStreak = calcPerfectDayStreak(habitsArr, last14Days);
+  // habitsWeekTrend: week-over-week direction — compares cur-7 rate vs prev-7 rate using the same 14-day window.
+  const habitsPrevWeekRate = calcHabitsWeekRate(habitsArr, last14Days.slice(0, 7));
+  const habitsWeekTrend = calcHabitsWeekTrend(habitsWeekRate, habitsPrevWeekRate);
   const habitsBadge = calcHabitsBadge({
     habitCount: habitsArr.length,
     doneToday: habitsDoneToday,
     atRisk: habitsAtRisk,
     weekRate: habitsWeekRate,
+    weekTrend: habitsWeekTrend,
     perfectStreak: habitsPerfectStreak,
   });
 

--- a/src/lib/habits.test.ts
+++ b/src/lib/habits.test.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Unit tests for calcHabitsWeekRate, calcHabitWeekStats, calcHabitsBadge, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo, calcTargetStreakPct, and playHabitCheck pure helpers
-// ABOUTME: Validates average daily completion rate, per-habit weekly trend statistics, section badge formatting, check-in/undo patch generation, perfect-day streak, milestone badges, completion tracking, target streak progress, and audio feedback
+// ABOUTME: Unit tests for calcHabitsWeekRate, calcHabitWeekStats, calcHabitsWeekTrend, calcHabitsBadge, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo, calcTargetStreakPct, and playHabitCheck pure helpers
+// ABOUTME: Validates average daily completion rate, per-habit weekly trend statistics, aggregate week-over-week trend, section badge formatting, check-in/undo patch generation, perfect-day streak, milestone badges, completion tracking, target streak progress, and audio feedback
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { calcHabitsWeekRate, calcHabitWeekStats, calcHabitsBadge, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo, calcTargetStreakPct, playHabitCheck } from "./habits";
+import { calcHabitsWeekRate, calcHabitWeekStats, calcHabitsWeekTrend, calcHabitsBadge, calcCheckInPatch, calcUndoCheckInPatch, calcPerfectDayStreak, getMilestone, getUpcomingMilestone, habitsTodayPct, habitLastCheckDaysAgo, calcTargetStreakPct, playHabitCheck } from "./habits";
 import type { Habit } from "../types";
 
 // Fixed 7-day window for deterministic tests (oldest → newest)
@@ -224,6 +224,48 @@ describe("calcHabitWeekStats", () => {
   });
 });
 
+describe("calcHabitsWeekTrend", () => {
+  it("should return null when curRate is null", () => {
+    expect(calcHabitsWeekTrend(null, 50)).toBeNull();
+  });
+
+  it("should return null when prevRate is null", () => {
+    expect(calcHabitsWeekTrend(50, null)).toBeNull();
+  });
+
+  it("should return null when both rates are null", () => {
+    expect(calcHabitsWeekTrend(null, null)).toBeNull();
+  });
+
+  it("should return ↑ when curRate > prevRate", () => {
+    expect(calcHabitsWeekTrend(80, 70)).toBe("↑");
+  });
+
+  it("should return ↓ when curRate < prevRate", () => {
+    expect(calcHabitsWeekTrend(60, 75)).toBe("↓");
+  });
+
+  it("should return → when curRate equals prevRate", () => {
+    expect(calcHabitsWeekTrend(75, 75)).toBe("→");
+  });
+
+  it("should return → when both rates are 0", () => {
+    expect(calcHabitsWeekTrend(0, 0)).toBe("→");
+  });
+
+  it("should return → when both rates are 100", () => {
+    expect(calcHabitsWeekTrend(100, 100)).toBe("→");
+  });
+
+  it("should return ↑ when curRate is 1 and prevRate is 0", () => {
+    expect(calcHabitsWeekTrend(1, 0)).toBe("↑");
+  });
+
+  it("should return ↓ when curRate is 0 and prevRate is 1", () => {
+    expect(calcHabitsWeekTrend(0, 1)).toBe("↓");
+  });
+});
+
 describe("calcHabitsBadge", () => {
   it("should return undefined when habitCount is 0", () => {
     expect(calcHabitsBadge({ habitCount: 0, doneToday: 0, atRisk: 0, weekRate: null })).toBeUndefined();
@@ -233,8 +275,33 @@ describe("calcHabitsBadge", () => {
     expect(calcHabitsBadge({ habitCount: 4, doneToday: 2, atRisk: 0, weekRate: null })).toBe("2/4");
   });
 
-  it("should append '7d·N%' when weekRate is non-null", () => {
+  it("should append '7d·N%' when weekRate is non-null and weekTrend is absent", () => {
     expect(calcHabitsBadge({ habitCount: 4, doneToday: 2, atRisk: 0, weekRate: 75 })).toBe("2/4 · 7d·75%");
+  });
+
+  it("should append trend arrow ↑ after weekRate when weekTrend is ↑", () => {
+    expect(calcHabitsBadge({ habitCount: 4, doneToday: 2, atRisk: 0, weekRate: 75, weekTrend: "↑" })).toBe("2/4 · 7d·75%↑");
+  });
+
+  it("should append trend arrow ↓ after weekRate when weekTrend is ↓", () => {
+    expect(calcHabitsBadge({ habitCount: 4, doneToday: 2, atRisk: 0, weekRate: 75, weekTrend: "↓" })).toBe("2/4 · 7d·75%↓");
+  });
+
+  it("should append trend arrow → after weekRate when weekTrend is →", () => {
+    expect(calcHabitsBadge({ habitCount: 4, doneToday: 2, atRisk: 0, weekRate: 75, weekTrend: "→" })).toBe("2/4 · 7d·75%→");
+  });
+
+  it("should not append trend arrow when weekTrend is null", () => {
+    expect(calcHabitsBadge({ habitCount: 4, doneToday: 2, atRisk: 0, weekRate: 75, weekTrend: null })).toBe("2/4 · 7d·75%");
+  });
+
+  it("should not append trend arrow when weekRate is null even if weekTrend is non-null", () => {
+    // weekTrend is meaningless without weekRate to display it on
+    expect(calcHabitsBadge({ habitCount: 4, doneToday: 2, atRisk: 0, weekRate: null, weekTrend: "↑" })).toBe("2/4");
+  });
+
+  it("should include trend in full badge with all parts", () => {
+    expect(calcHabitsBadge({ habitCount: 5, doneToday: 3, atRisk: 1, weekRate: 80, weekTrend: "↑", perfectStreak: 4 })).toBe("3/5 · 7d·80%↑ · ⚠1 · 4🌟");
   });
 
   it("should append '⚠N' when atRisk > 0", () => {

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Pure helpers for habit statistics and check-in logic, plus audio feedback
-// ABOUTME: Covers milestone badges, completion tracking, per-habit weekly trend stats, aggregate daily completion rate, section badge, check-in patch, perfect-day streak, and habit check-in audio cue
+// ABOUTME: Covers milestone badges, completion tracking, per-habit weekly trend stats, aggregate week-over-week trend, daily completion rate, section badge, check-in patch, perfect-day streak, and habit check-in audio cue
 
 import type { Habit } from "../types";
 
@@ -77,6 +77,19 @@ export function calcHabitsWeekRate(habits: Habit[], dayWindow: string[]): number
   return Math.round(avgRate * 100);
 }
 
+// Returns ↑ when curRate > prevRate, ↓ when curRate < prevRate, → when equal (both non-null).
+// Returns null when either rate is null — no baseline exists to compute a meaningful trend.
+// Exported for unit testing; pure function with no side effects.
+export function calcHabitsWeekTrend(
+  curRate: number | null,
+  prevRate: number | null,
+): "↑" | "↓" | "→" | null {
+  if (curRate === null || prevRate === null) return null;
+  if (curRate > prevRate) return "↑";
+  if (curRate < prevRate) return "↓";
+  return "→";
+}
+
 export interface HabitsBadgeParams {
   /** Total habit count; returns undefined when 0. */
   habitCount: number;
@@ -88,6 +101,8 @@ export interface HabitsBadgeParams {
   weekRate: number | null;
   /** Consecutive days where ALL habits were completed; ≥2 triggers N🌟 suffix. */
   perfectStreak?: number;
+  /** Week-over-week trend: ↑/↓/→ appended after weekRate when non-null; absent/null = no arrow. */
+  weekTrend?: "↑" | "↓" | "→" | null;
 }
 
 /**
@@ -102,13 +117,14 @@ export interface HabitsBadgeParams {
  * - N🌟: consecutive all-habits-done days (e.g. "3🌟"); omitted when perfectStreak < 2
  */
 export function calcHabitsBadge(params: HabitsBadgeParams): string | undefined {
-  const { habitCount, doneToday, atRisk, weekRate, perfectStreak } = params;
+  const { habitCount, doneToday, atRisk, weekRate, perfectStreak, weekTrend } = params;
   if (habitCount === 0) return undefined;
   const allDone = doneToday >= habitCount;
   const countStr = allDone ? `✓${doneToday}/${habitCount}` : `${doneToday}/${habitCount}`;
+  const trendSuffix = weekRate !== null && weekTrend ? weekTrend : "";
   return [
     countStr,
-    weekRate !== null ? `7d·${weekRate}%` : null,
+    weekRate !== null ? `7d·${weekRate}%${trendSuffix}` : null,
     atRisk > 0 ? `⚠${atRisk}` : null,
     (perfectStreak ?? 0) >= 2 ? `${perfectStreak}🌟` : null,
   ].filter(Boolean).join(" · ");


### PR DESCRIPTION
## Summary
- `calcHabitsWeekTrend` 순수 함수 추가 — curRate vs prevRate 비교로 ↑/↓/→ 반환
- `HabitsBadgeParams`에 `weekTrend?: "↑" | "↓" | "→" | null` 추가
- 습관 섹션 배지 형식: `7d·80%` → `7d·80%↑` (추세 표시)
- `App.tsx`: `last14Days.slice(0,7)` 이전주 완료율 계산, 트렌드 배지에 전달

## Changes
- `src/lib/habits.ts`: `calcHabitsWeekTrend` + `HabitsBadgeParams.weekTrend` + `calcHabitsBadge` 업데이트
- `src/lib/habits.test.ts`: 16개 테스트 추가 (1059→1075)
- `src/App.tsx`: prev-week rate 계산 + `habitsWeekTrend` 전달

## 선택 근거
개인 대시보드에서 스트릭 섹션 배지(`7d·80%`)는 현재 주간 달성률만 보여주고 방향성을 알 수 없음. ↑/↓/→ 추가로 "개선 중인지" 한 눈에 파악. `calcIntentionWeekTrend`(의도 섹션) 패턴과 일관성 유지.

---
_자율 개발 에이전트가 생성한 PR_