### PR TITLE
feat(#27): GitHub 이벤트·포모도로 집중 시작 알림 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -197,9 +197,34 @@ export default function App() {
 
   // Atomic batch update for GitHub polling — applies all results in one persist
   // to avoid the stale-closure overwrite race when multiple projects complete in parallel.
+  // Also detects new commits/PRs/issues vs previous snapshot and sends desktop notifications.
   const batchUpdateProjects = useCallback((updates: Array<{ id: number; patch: Partial<Project> }>) => {
     if (updates.length === 0) return;
     const snapshot = dataRef.current;
+    (async () => {
+      try {
+        let ok = await isPermissionGranted();
+        if (!ok) { const perm = await requestPermission(); ok = perm === "granted"; }
+        if (!ok) return;
+        for (const update of updates) {
+          if (!update.patch.githubData) continue;
+          const old = snapshot.projects.find(p => p.id === update.id);
+          if (!old?.githubData) continue;
+          const prev = old.githubData;
+          const fresh = update.patch.githubData;
+          const name = old.name ?? `#${update.id}`;
+          if (fresh.lastCommitAt && prev.lastCommitAt && fresh.lastCommitAt > prev.lastCommitAt) {
+            sendNotification({ title: "Vision Widget", body: `${name}: 새 커밋이 추가됐습니다.` });
+          }
+          if (typeof fresh.openPrs === "number" && typeof prev.openPrs === "number" && fresh.openPrs > prev.openPrs) {
+            sendNotification({ title: "Vision Widget", body: `${name}: PR ${fresh.openPrs - prev.openPrs}개 추가됐습니다.` });
+          }
+          if (typeof fresh.openIssues === "number" && typeof prev.openIssues === "number" && fresh.openIssues > prev.openIssues) {
+            sendNotification({ title: "Vision Widget", body: `${name}: 이슈 ${fresh.openIssues - prev.openIssues}개 추가됐습니다.` });
+          }
+        }
+      } catch { /* not available in browser dev mode */ }
+    })();
     const next = {
       ...snapshot,
       projects: snapshot.projects.map(p => {

--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -592,7 +592,12 @@ export function PomodoroTimer({ initialDurations, onDurationsChange, sessionsTod
           {/* Controls */}
           <div style={{ display: "flex", gap: 8 }}>
             <button
-              onClick={() => setRunning(r => !r)}
+              onClick={async () => {
+                if (!running && !isPaused && phase === "focus" && notifyRef.current) {
+                  await notify("Vision Widget", "🎯 집중 시작!");
+                }
+                setRunning(r => !r);
+              }}
               style={{
                 flex: 1, padding: "6px 0", borderRadius: radius.chip,
                 background: running ? `${phaseColor}22` : `${phaseColor}33`,


### PR DESCRIPTION
Closes #27

## 변경사항

### GitHub 이벤트 알림 (`src/App.tsx`)
`batchUpdateProjects` 콜백에서 GitHub 폴링 결과와 이전 데이터를 비교하여 변화 감지:
- 새 커밋: `lastCommitAt` ISO 8601 datetime 사전식 비교
- 새 PR: `openPrs` 증가 감지 (추가된 개수 포함)
- 새 이슈: `openIssues` 증가 감지 (추가된 개수 포함)

기존 `isPermissionGranted → requestPermission → sendNotification` 패턴 그대로 재사용.

### 포모도로 집중 시작 알림 (`src/components/PomodoroTimer.tsx`)
▶ 시작 버튼 클릭 시 `!running && !isPaused && phase === "focus"` 조건을 만족하면 "🎯 집중 시작!" 알림 발송.
- `isPaused` 조건으로 일시정지 후 재개는 알림 제외 (매번 울리는 노이즈 방지)
- 기존 `notify()` 헬퍼 재사용, `notifyRef.current`로 사용자 토글 존중

## 동작 안 하는 케이스 (의도된 한계)
- 앱 첫 실행 시에는 `prev.githubData`가 없어 알림 없음 (2회차 폴링부터 작동)
- PR/이슈가 100개 초과이면 `openPrs` 변화 미감지 가능 (기존 `github.ts` 페이지 제한)