### PR TITLE
feat(pomodoro): calcPomodoroEveningReminder — 저녁 포모도로 미달성 알림

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQu
 import { calcGoalExpiry } from "./lib/goalExpiry";
 import { calcDirectionBadge } from "./lib/direction";
 import { calcProjectsBadge, calcProjectMilestone } from "./lib/projects";
-import { calcTodaySessionCount, updatePomodoroHistory, calcPomodoroMorningReminder } from "./lib/pomodoro";
+import { calcTodaySessionCount, updatePomodoroHistory, calcPomodoroMorningReminder, calcPomodoroEveningReminder } from "./lib/pomodoro";
 import { calcDailyScore, updateMomentumHistory, calcMomentumStreak, calcMomentumWeekAvg } from "./lib/momentum";
 import { calcTodayInsight } from "./lib/insight";
 import { Clock } from "./components/Clock";
@@ -426,6 +426,29 @@ export default function App() {
       } catch { /* not available in browser dev mode */ }
     })();
   }, [data.pomodoroSessionsDate, data.pomodoroSessions, data.pomodoroMorningRemindDate, loaded, persist]);
+
+  // pomodoroEveningRemindDate persists the guard so it fires only once per calendar day even after restart.
+  // Fires after 17:00 when the user has not yet met their daily session goal (or has 0 sessions when no goal set).
+  // Design: date is persisted before the async send (same pattern as pomodoroMorningRemindDate) to prevent duplicates.
+  useEffect(() => {
+    if (!loaded) return;
+    const now = new Date();
+    const today = now.toLocaleDateString("sv");
+    if (data.pomodoroEveningRemindDate === today) return;
+    if (now.getHours() < 17) return;
+    const sessionsToday = data.pomodoroSessionsDate === today ? (data.pomodoroSessions ?? 0) : 0;
+    const msg = calcPomodoroEveningReminder(sessionsToday, data.pomodoroSessionGoal);
+    if (!msg) return;
+    persist({ ...dataRef.current, pomodoroEveningRemindDate: today });
+    (async () => {
+      try {
+        let ok = await isPermissionGranted();
+        if (!ok) { const perm = await requestPermission(); ok = perm === "granted"; }
+        if (!ok) return;
+        sendNotification({ title: "Vision Widget", body: msg });
+      } catch { /* not available in browser dev mode */ }
+    })();
+  }, [data.pomodoroSessionsDate, data.pomodoroSessions, data.pomodoroSessionGoal, data.pomodoroEveningRemindDate, loaded, persist]);
 
   // Habit milestone approach nudge — fires once per calendar day at 09:00+ (same window as intention reminder)
   // when any habit is within 3 days of its next streak milestone (7🔥/30⭐/100💎).

--- a/src/lib/pomodoro.test.ts
+++ b/src/lib/pomodoro.test.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Unit tests for pomodoro pure helpers — calcTodaySessionCount, updatePomodoroHistory, calcLast14Days, calcSessionWeekTrend, calcSessionCountStr, calcPomodoroBadge, calcFocusStreak, phaseAccent, phaseLabel, sessionGoalPct, formatLifetime, playPhaseDone, calcPomodoroMorningReminder
-// ABOUTME: Covers today-count reset/increment, 14-day history upsert, date range derivation, prev-7/cur-7 trend logic, badge string (incl. week sessions 7d·N↑), focus streak, section collapsed badge, phase UI mapping, goal-progress percentage, lifetime format, audio feedback graceful fallback, and morning start nudge
+// ABOUTME: Unit tests for pomodoro pure helpers — calcTodaySessionCount, updatePomodoroHistory, calcLast14Days, calcSessionWeekTrend, calcSessionCountStr, calcPomodoroBadge, calcFocusStreak, phaseAccent, phaseLabel, sessionGoalPct, formatLifetime, playPhaseDone, calcPomodoroMorningReminder, calcPomodoroEveningReminder
+// ABOUTME: Covers today-count reset/increment, 14-day history upsert, date range derivation, prev-7/cur-7 trend logic, badge string (incl. week sessions 7d·N↑), focus streak, section collapsed badge, phase UI mapping, goal-progress percentage, lifetime format, audio feedback graceful fallback, morning start nudge, and evening goal-gap nudge
 
 import { describe, it, expect } from "vitest";
-import { calcLast14Days, calcSessionWeekTrend, calcTodaySessionCount, updatePomodoroHistory, calcSessionCountStr, calcPomodoroBadge, calcFocusStreak, phaseAccent, phaseLabel, sessionGoalPct, formatLifetime, playPhaseDone, calcPomodoroMorningReminder } from "./pomodoro";
+import { calcLast14Days, calcSessionWeekTrend, calcTodaySessionCount, updatePomodoroHistory, calcSessionCountStr, calcPomodoroBadge, calcFocusStreak, phaseAccent, phaseLabel, sessionGoalPct, formatLifetime, playPhaseDone, calcPomodoroMorningReminder, calcPomodoroEveningReminder } from "./pomodoro";
 import { colors } from "../theme";
 import type { PomodoroDay } from "../types";
 
@@ -607,5 +607,47 @@ describe("calcPomodoroMorningReminder", () => {
 
   it("should return nudge body when sessionsToday is negative (caller guarantees ≥0; negative treated as no sessions)", () => {
     expect(calcPomodoroMorningReminder(-1)).toBe("🍅 오늘 집중 세션을 시작해보세요!");
+  });
+});
+
+describe("calcPomodoroEveningReminder", () => {
+  it("should return reminder body when no goal and 0 sessions today", () => {
+    expect(calcPomodoroEveningReminder(0, undefined)).toBe("🍅 오늘 아직 집중 세션이 없어요!");
+  });
+
+  it("should return null when no goal and 1 session done", () => {
+    expect(calcPomodoroEveningReminder(1, undefined)).toBeNull();
+  });
+
+  it("should return null when no goal and multiple sessions done", () => {
+    expect(calcPomodoroEveningReminder(4, undefined)).toBeNull();
+  });
+
+  it("should return reminder with full gap when goal set and 0 sessions done", () => {
+    expect(calcPomodoroEveningReminder(0, 4)).toBe("🍅 목표까지 4세션 남았어요! (0/4)");
+  });
+
+  it("should return reminder with partial gap when goal set and partially done", () => {
+    expect(calcPomodoroEveningReminder(2, 4)).toBe("🍅 목표까지 2세션 남았어요! (2/4)");
+  });
+
+  it("should return null when goal exactly reached", () => {
+    expect(calcPomodoroEveningReminder(4, 4)).toBeNull();
+  });
+
+  it("should return null when sessions exceed goal", () => {
+    expect(calcPomodoroEveningReminder(5, 4)).toBeNull();
+  });
+
+  it("should treat sessionGoal=0 as no goal (returns reminder when 0 sessions)", () => {
+    expect(calcPomodoroEveningReminder(0, 0)).toBe("🍅 오늘 아직 집중 세션이 없어요!");
+  });
+
+  it("should return reminder body when sessionsToday is negative and no goal (clamped to 0)", () => {
+    expect(calcPomodoroEveningReminder(-1, undefined)).toBe("🍅 오늘 아직 집중 세션이 없어요!");
+  });
+
+  it("should return reminder body when sessionsToday is negative with goal set (clamped to 0, displays 0/goal)", () => {
+    expect(calcPomodoroEveningReminder(-1, 4)).toBe("🍅 목표까지 4세션 남았어요! (0/4)");
   });
 });

--- a/src/lib/pomodoro.ts
+++ b/src/lib/pomodoro.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Helpers for pomodoro session statistics, phase UI mapping, audio feedback, and morning start nudge
-// ABOUTME: Covers phase color/label, today-count derivation, 14-day history upsert, date range, week trend, header badge string, focus streak, lifetime format, goal-progress percentage, session-end audio cue, and morning reminder
+// ABOUTME: Helpers for pomodoro session statistics, phase UI mapping, audio feedback, morning start nudge, and evening goal-gap nudge
+// ABOUTME: Covers phase color/label, today-count derivation, 14-day history upsert, date range, week trend, header badge string, focus streak, lifetime format, goal-progress percentage, session-end audio cue, morning reminder, and evening reminder
 
 import type { PomodoroDay } from "../types";
 import { colors } from "../theme";
@@ -223,4 +223,26 @@ export function calcPomodoroMorningReminder(
 ): string | null {
   if (sessionsToday > 0) return null;
   return "🍅 오늘 집중 세션을 시작해보세요!";
+}
+
+// Returns the desktop notification body when the daily pomodoro goal has not been reached by evening.
+// When sessionGoal is set (>0): returns null once sessions >= sessionGoal; otherwise returns the remaining-session count with progress context.
+// When sessionGoal is absent/0: returns null once any session has been completed; otherwise returns a generic no-session nudge.
+// Hour/date guards live in the caller (App.tsx useEffect) — fires after 17:00 via pomodoroEveningRemindDate guard.
+// Callers should check pomodoroEveningRemindDate before invoking to ensure once-per-day delivery.
+// sessionsToday: caller guarantees ≥0; negative values are clamped to 0 in both goal-set and no-goal paths.
+// sessionGoal: absent/0 = no daily goal (1-session threshold applies); positive integer = explicit goal.
+export function calcPomodoroEveningReminder(
+  sessionsToday: number,
+  sessionGoal: number | undefined,
+): string | null {
+  const sessions = Math.max(0, sessionsToday); // clamp: negative values treated as 0 — caller guarantees ≥0
+  const hasGoal = sessionGoal != null && sessionGoal > 0;
+  if (hasGoal) {
+    if (sessions >= sessionGoal!) return null;
+    const remaining = sessionGoal! - sessions;
+    return `🍅 목표까지 ${remaining}세션 남았어요! (${sessions}/${sessionGoal})`;
+  }
+  if (sessions > 0) return null;
+  return "🍅 오늘 아직 집중 세션이 없어요!";
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export interface WidgetData {
   intentionMorningRemindDate?: string; // YYYY-MM-DD date when the morning intention-setter reminder was sent; absent = not sent
   intentionEveningRemindDate?: string; // YYYY-MM-DD date when the evening intention done-check reminder was sent; absent = not sent
   pomodoroMorningRemindDate?: string;  // YYYY-MM-DD date when the morning pomodoro start nudge was sent; absent = not sent
+  pomodoroEveningRemindDate?: string;  // YYYY-MM-DD date when the evening pomodoro goal-gap nudge was sent; absent = not sent
   habitMilestoneApproachDate?: string; // YYYY-MM-DD date when the habit milestone approach nudge was sent; absent = not sent
   weekGoalHistory?: GoalEntry[];   // rolling log of past weekly goals; newest last; capped at 8 entries; absent = no history
   monthGoalHistory?: GoalEntry[];  // rolling log of past monthly goals; newest last; capped at 12 entries; absent = no history


### PR DESCRIPTION
## Summary
- 17:00 이후 일일 포모도로 목표 미달성 시 데스크탑 알림 전송
- 목표 설정 시: "🍅 목표까지 N세션 남았어요! (done/goal)" 형식
- 목표 미설정 시: 세션 0개일 때만 "🍅 오늘 아직 집중 세션이 없어요!" 알림
- `pomodoroEveningRemindDate` 날짜 가드로 하루 1회 보장

## Changes
- `src/lib/pomodoro.ts`: `calcPomodoroEveningReminder` 순수 함수 추가 (음수 clamp 포함)
- `src/lib/pomodoro.test.ts`: 10 테스트 추가 (1256 → 1266)
- `src/types.ts`: `pomodoroEveningRemindDate` 필드 추가
- `src/App.tsx`: useEffect 추가, import 갱신

## 선택 근거
`calcPomodoroMorningReminder`(10시 이후 시작 독려)의 짝이 되는 저녁 알림이 부재했음. 외부 API 없이 기존 패턴 완전 준수, 4파일 변경으로 scope-limit 이내.

---
_자율 개발 에이전트가 생성한 PR_