### PR TITLE
fix(#32): Rust WidgetData 누락 필드 추가 — 데이터 저장/불러오기 버그 수정

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,8 @@ pub struct WidgetSettings {
     pub github_pat: Option<String>,
     #[serde(rename = "githubRefreshInterval", default, skip_serializing_if = "Option::is_none")]
     pub github_refresh_interval: Option<u32>,
+    #[serde(rename = "pinned", default, skip_serializing_if = "Option::is_none")]
+    pub pinned: Option<bool>,
 }
 
 const VALID_THEMES: &[&str] = &["void", "nebula", "forest", "ember", "midnight", "aurora", "rose"];
@@ -224,6 +226,33 @@ pub struct WidgetData {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "yearGoalHistory")]
     pub year_goal_history: Option<Vec<GoalEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "pomodoroSound", default)]
+    pub pomodoro_sound: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "habitsSound", default)]
+    pub habits_sound: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "momentumHistory", default)]
+    pub momentum_history: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "habitEveningRemindDate", default)]
+    pub habit_evening_remind_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "intentionMorningRemindDate", default)]
+    pub intention_morning_remind_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "intentionEveningRemindDate", default)]
+    pub intention_evening_remind_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "pomodoroMorningRemindDate", default)]
+    pub pomodoro_morning_remind_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "pomodoroEveningRemindDate", default)]
+    pub pomodoro_evening_remind_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "habitMilestoneApproachDate", default)]
+    pub habit_milestone_approach_date: Option<String>,
 }
 
 fn get_data_path() -> PathBuf {
@@ -247,6 +276,7 @@ fn default_settings() -> WidgetSettings {
         clock_format: "24h".to_string(),
         github_pat: None,
         github_refresh_interval: None,
+        pinned: None,
     }
 }
 
@@ -372,7 +402,29 @@ fn default_data() -> WidgetData {
         month_goal_history: None,
         quarter_goal_history: None,
         year_goal_history: None,
+        pomodoro_sound: None,
+        habits_sound: None,
+        momentum_history: None,
+        habit_evening_remind_date: None,
+        intention_morning_remind_date: None,
+        intention_evening_remind_date: None,
+        pomodoro_morning_remind_date: None,
+        pomodoro_evening_remind_date: None,
+        habit_milestone_approach_date: None,
     }
+}
+
+/// Validates an optional YYYY-MM-DD date string; returns None for any invalid value.
+pub(crate) fn sanitize_ymd_date(d: Option<String>) -> Option<String> {
+    d.as_deref()
+        .filter(|s| {
+            let b = s.as_bytes();
+            s.len() == 10
+                && b.iter().all(|&x| x.is_ascii_digit() || x == b'-')
+                && b[4] == b'-'
+                && b[7] == b'-'
+        })
+        .map(String::from)
 }
 
 #[tauri::command]
@@ -458,20 +510,8 @@ fn load_data() -> WidgetData {
     if data.today_intention.as_deref() == Some("") {
         data.today_intention = None;
     }
-    // Sanitize today_intention_date: must be YYYY-MM-DD format (length 10, digit/dash chars, hyphens at positions 4 and 7)
-    match &data.today_intention_date {
-        Some(d) => {
-            let bytes = d.as_bytes();
-            let valid = d.len() == 10
-                && bytes.iter().all(|&b| b.is_ascii_digit() || b == b'-')
-                && bytes[4] == b'-'
-                && bytes[7] == b'-';
-            if !valid {
-                data.today_intention_date = None;
-            }
-        }
-        None => {}
-    }
+    // Sanitize today_intention_date: must be YYYY-MM-DD format
+    data.today_intention_date = sanitize_ymd_date(data.today_intention_date);
     // Sanitize today_intention_done: clear if intention is absent (done without an intention is meaningless)
     if data.today_intention.is_none() {
         data.today_intention_done = None;
@@ -752,46 +792,21 @@ fn load_data() -> WidgetData {
             .filter(|s| !s.is_empty())
             .map(String::from);
         // last_focus_date: must be strict YYYY-MM-DD format; any other value → None
-        project.last_focus_date = project.last_focus_date.as_deref()
-            .filter(|s| {
-                let b = s.as_bytes();
-                s.len() == 10
-                    && b.iter().all(|&x| x.is_ascii_digit() || x == b'-')
-                    && b[4] == b'-'
-                    && b[7] == b'-'
-            })
-            .map(String::from);
+        project.last_focus_date = sanitize_ymd_date(project.last_focus_date.take());
         // completed_date: must be strict YYYY-MM-DD format; any other value → None
-        project.completed_date = project.completed_date.as_deref()
-            .filter(|s| {
-                let b = s.as_bytes();
-                s.len() == 10
-                    && b.iter().all(|&x| x.is_ascii_digit() || x == b'-')
-                    && b[4] == b'-'
-                    && b[7] == b'-'
-            })
-            .map(String::from);
+        project.completed_date = sanitize_ymd_date(project.completed_date.take());
         // created_date: must be strict YYYY-MM-DD format; any other value → None
-        project.created_date = project.created_date.as_deref()
-            .filter(|s| {
-                let b = s.as_bytes();
-                s.len() == 10
-                    && b.iter().all(|&x| x.is_ascii_digit() || x == b'-')
-                    && b[4] == b'-'
-                    && b[7] == b'-'
-            })
-            .map(String::from);
+        project.created_date = sanitize_ymd_date(project.created_date.take());
     }
     // Sanitize habits_all_done_date: must be strict YYYY-MM-DD format; any other value → None
-    data.habits_all_done_date = data.habits_all_done_date.as_deref()
-        .filter(|s| {
-            let b = s.as_bytes();
-            s.len() == 10
-                && b.iter().all(|&x| x.is_ascii_digit() || x == b'-')
-                && b[4] == b'-'
-                && b[7] == b'-'
-        })
-        .map(String::from);
+    data.habits_all_done_date = sanitize_ymd_date(data.habits_all_done_date);
+    // Sanitize remind/milestone date fields: must be strict YYYY-MM-DD format; any other value → None
+    data.habit_evening_remind_date = sanitize_ymd_date(data.habit_evening_remind_date);
+    data.intention_morning_remind_date = sanitize_ymd_date(data.intention_morning_remind_date);
+    data.intention_evening_remind_date = sanitize_ymd_date(data.intention_evening_remind_date);
+    data.pomodoro_morning_remind_date = sanitize_ymd_date(data.pomodoro_morning_remind_date);
+    data.pomodoro_evening_remind_date = sanitize_ymd_date(data.pomodoro_evening_remind_date);
+    data.habit_milestone_approach_date = sanitize_ymd_date(data.habit_milestone_approach_date);
     data
 }
 
@@ -853,6 +868,8 @@ pub fn run() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
+
+mod widget_data_fields_test;
 
 fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
     use tauri::{

--- a/src-tauri/src/widget_data_fields_test.rs
+++ b/src-tauri/src/widget_data_fields_test.rs
@@ -1,0 +1,248 @@
+// ABOUTME: WidgetData/WidgetSettings 누락 필드 및 직렬화 불변식 검증
+// ABOUTME: serde 직렬화/역직렬화 왕복(round-trip), None→absent, 날짜 sanitize 포함
+
+#[cfg(test)]
+mod tests {
+    use crate::{sanitize_ymd_date, WidgetData, WidgetSettings};
+
+    // ─── WidgetData 누락 필드: 역직렬화 보존 테스트 ─────────────────────────
+
+    /// JSON에 pomodoroSound 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_pomodoro_sound_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "pomodoroSound": true
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(data.pomodoro_sound, Some(true));
+    }
+
+    /// JSON에 habitsSound 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_habits_sound_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "habitsSound": false
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(data.habits_sound, Some(false));
+    }
+
+    /// JSON에 momentumHistory 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_momentum_history_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "momentumHistory": [{"date": "2026-03-16", "score": 5}]
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert!(data.momentum_history.is_some());
+    }
+
+    /// JSON에 habitEveningRemindDate 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_habit_evening_remind_date_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "habitEveningRemindDate": "2026-03-16"
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(data.habit_evening_remind_date, Some("2026-03-16".to_string()));
+    }
+
+    /// JSON에 intentionMorningRemindDate 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_intention_morning_remind_date_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "intentionMorningRemindDate": "2026-03-16"
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(data.intention_morning_remind_date, Some("2026-03-16".to_string()));
+    }
+
+    /// JSON에 intentionEveningRemindDate 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_intention_evening_remind_date_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "intentionEveningRemindDate": "2026-03-16"
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(data.intention_evening_remind_date, Some("2026-03-16".to_string()));
+    }
+
+    /// JSON에 pomodoroMorningRemindDate 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_pomodoro_morning_remind_date_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "pomodoroMorningRemindDate": "2026-03-16"
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(data.pomodoro_morning_remind_date, Some("2026-03-16".to_string()));
+    }
+
+    /// JSON에 pomodoroEveningRemindDate 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_pomodoro_evening_remind_date_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "pomodoroEveningRemindDate": "2026-03-16"
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(data.pomodoro_evening_remind_date, Some("2026-03-16".to_string()));
+    }
+
+    /// JSON에 habitMilestoneApproachDate 필드가 있으면 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_habit_milestone_approach_date_when_deserializing() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "habitMilestoneApproachDate": "2026-03-16"
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(data.habit_milestone_approach_date, Some("2026-03-16".to_string()));
+    }
+
+    // ─── WidgetData 직렬화: 필드가 JSON 출력에 포함되는지 ──────────────────
+
+    /// WidgetData를 직렬화하면 pomodoroSound 필드가 JSON에 포함되어야 한다
+    #[test]
+    fn should_serialize_pomodoro_sound_to_json() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "pomodoroSound": true
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        let serialized = serde_json::to_string(&data).expect("serialization failed");
+        assert!(
+            serialized.contains("\"pomodoroSound\""),
+            "serialized JSON does not contain 'pomodoroSound': {serialized}"
+        );
+    }
+
+    /// WidgetData를 직렬화하면 habitsSound 필드가 JSON에 포함되어야 한다
+    #[test]
+    fn should_serialize_habits_sound_to_json() {
+        let json = r#"{
+            "projects": [],
+            "habits": [],
+            "quotes": [],
+            "habitsSound": false
+        }"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        let serialized = serde_json::to_string(&data).expect("serialization failed");
+        assert!(
+            serialized.contains("\"habitsSound\""),
+            "serialized JSON does not contain 'habitsSound': {serialized}"
+        );
+    }
+
+    // ─── WidgetSettings 누락 필드: pinned ──────────────────────────────────
+
+    /// JSON에 pinned 필드가 있으면 WidgetSettings 역직렬화 후에도 보존되어야 한다
+    #[test]
+    fn should_preserve_pinned_in_widget_settings_when_deserializing() {
+        let json = r#"{
+            "position": {"x": 0, "y": 0},
+            "size": {"width": 380, "height": 700},
+            "opacity": 1.0,
+            "pinned": true
+        }"#;
+        let settings: WidgetSettings = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(settings.pinned, Some(true));
+    }
+
+    /// WidgetSettings를 직렬화하면 pinned 필드가 JSON에 포함되어야 한다
+    #[test]
+    fn should_serialize_pinned_in_widget_settings_to_json() {
+        let json = r#"{
+            "position": {"x": 0, "y": 0},
+            "size": {"width": 380, "height": 700},
+            "opacity": 1.0,
+            "pinned": true
+        }"#;
+        let settings: WidgetSettings = serde_json::from_str(json).expect("deserialization failed");
+        let serialized = serde_json::to_string(&settings).expect("serialization failed");
+        assert!(
+            serialized.contains("\"pinned\""),
+            "serialized JSON does not contain 'pinned': {serialized}"
+        );
+    }
+
+    /// None 값 필드는 직렬화 시 JSON에 없어야 한다 (null이 아닌 absent)
+    #[test]
+    fn should_omit_none_fields_when_serializing() {
+        let json = r#"{"projects": [], "habits": [], "quotes": []}"#;
+        let data: WidgetData = serde_json::from_str(json).expect("deserialization failed");
+        let serialized = serde_json::to_string(&data).expect("serialization failed");
+        for field in &[
+            "pomodoroSound", "habitsSound", "momentumHistory",
+            "habitEveningRemindDate", "intentionMorningRemindDate",
+            "intentionEveningRemindDate", "pomodoroMorningRemindDate",
+            "pomodoroEveningRemindDate", "habitMilestoneApproachDate",
+        ] {
+            assert!(
+                !serialized.contains(&format!("\"{}\":null", field)),
+                "{field} should be absent (not null) when None: {serialized}"
+            );
+        }
+    }
+
+    /// 기존 settings 파일에 pinned 키가 없어도 역직렬화가 성공해야 한다
+    #[test]
+    fn should_deserialize_widget_settings_without_pinned_field() {
+        let json = r#"{
+            "position": {"x": 0, "y": 0},
+            "size": {"width": 380, "height": 700},
+            "opacity": 1.0
+        }"#;
+        let settings: WidgetSettings = serde_json::from_str(json).expect("deserialization should succeed without pinned");
+        assert_eq!(settings.pinned, None);
+    }
+
+    // ─── sanitize_ymd_date ──────────────────────────────────────────────────
+
+    /// 유효한 YYYY-MM-DD 날짜는 그대로 반환되어야 한다
+    #[test]
+    fn should_pass_valid_ymd_date() {
+        assert_eq!(sanitize_ymd_date(Some("2026-03-16".into())), Some("2026-03-16".into()));
+    }
+
+    /// 잘못된 형식의 날짜 문자열은 None으로 변환되어야 한다
+    #[test]
+    fn should_reject_invalid_ymd_date() {
+        assert_eq!(sanitize_ymd_date(Some("not-a-date".into())), None);
+        assert_eq!(sanitize_ymd_date(Some("2026/03/16".into())), None);
+        assert_eq!(sanitize_ymd_date(Some("2026-3-16".into())), None);
+        assert_eq!(sanitize_ymd_date(Some("".into())), None);
+    }
+
+    /// None 입력은 None을 반환해야 한다
+    #[test]
+    fn should_pass_none_ymd_date() {
+        assert_eq!(sanitize_ymd_date(None), None);
+    }
+}


### PR DESCRIPTION
Closes #32

## 원인

Rust `WidgetData` 구조체에 TypeScript `WidgetData` 인터페이스의 9개 필드가 누락되어 있었음.
Tauri IPC `save_data` 호출 시 serde가 알 수 없는 필드를 silently drop → JSON에 저장 안 됨 → 앱 재시작 후 유실.

PAT만 살아남던 이유: PAT는 `WidgetSettings`에 `github_pat`으로 정의되어 있어서 정상 저장됨.

## 변경 내용

- `WidgetData` 구조체에 9개 필드 추가 (`skip_serializing_if`, `default`, serde rename 포함):
  `pomodoroSound`, `habitsSound`, `momentumHistory`, `habitEveningRemindDate`, `intentionMorningRemindDate`, `intentionEveningRemindDate`, `pomodoroMorningRemindDate`, `pomodoroEveningRemindDate`, `habitMilestoneApproachDate`
- `WidgetSettings.pinned`에 `default, skip_serializing_if = "Option::is_none"` 추가
- `sanitize_ymd_date()` 헬퍼 함수 추출 → 기존 5개 인라인 날짜 검증 중복 제거
- 테스트 18개: 역직렬화 보존, None→absent 직렬화, 날짜 sanitize, 기존 파일 하위 호환