### PR TITLE
feat(goals): 월간/분기 목표 마감 데스크탑 알림 추가

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,6 +250,10 @@ pub struct WidgetData {
     pub habit_milestone_approach_date: Option<String>,
     #[serde(rename = "weeklyReviewRemindDate", default, skip_serializing_if = "Option::is_none")]
     pub weekly_review_remind_date: Option<String>,
+    #[serde(rename = "monthGoalRemindDate", default, skip_serializing_if = "Option::is_none")]
+    pub month_goal_remind_date: Option<String>,
+    #[serde(rename = "quarterGoalRemindDate", default, skip_serializing_if = "Option::is_none")]
+    pub quarter_goal_remind_date: Option<String>,
     #[serde(rename = "habitsSound", default, skip_serializing_if = "Option::is_none")]
     pub habits_sound: Option<bool>,
     #[serde(rename = "pomodoroSound", default, skip_serializing_if = "Option::is_none")]
@@ -411,6 +415,8 @@ fn default_data() -> WidgetData {
         pomodoro_evening_remind_date: None,
         habit_milestone_approach_date: None,
         weekly_review_remind_date: None,
+        month_goal_remind_date: None,
+        quarter_goal_remind_date: None,
         habits_sound: None,
         pomodoro_sound: None,
     }
@@ -805,6 +811,10 @@ fn load_data() -> WidgetData {
     data.habit_milestone_approach_date = data.habit_milestone_approach_date.as_deref()
         .filter(|s| is_valid_ymd(s)).map(String::from);
     data.weekly_review_remind_date = data.weekly_review_remind_date.as_deref()
+        .filter(|s| is_valid_ymd(s)).map(String::from);
+    data.month_goal_remind_date = data.month_goal_remind_date.as_deref()
+        .filter(|s| is_valid_ymd(s)).map(String::from);
+    data.quarter_goal_remind_date = data.quarter_goal_remind_date.as_deref()
         .filter(|s| is_valid_ymd(s)).map(String::from);
     // Sanitize momentum_history: validate dates, guard NaN, clamp score 0–100, validate tier,
     // sort desc → dedup by date (keeps newest per date) → truncate to 7 → sort asc.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { fetchRepoData } from "./lib/github";
 import { totalDaysInMonth, totalDaysInQuarter, totalDaysInYear, periodElapsedFraction, daysLeftInWeek, daysLeftInMonth, daysLeftInQuarter, daysLeftInYear, calcLastNDays } from "./lib/datePeriods";
 import { calcIntentionStreak, calcIntentionWeek, calcIntentionWeekTrend, calcIntentionDoneNotify, calcMorningIntentionReminder, calcIntentionEveningReminder } from "./lib/intention";
 import { calcHabitsWeekRate, calcHabitsWeekTrend, calcHabitsBadge, calcPerfectDayStreak, calcEveningHabitReminder, calcHabitMilestoneApproachNotify, calcWeeklyReviewReminder } from "./lib/habits";
-import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQuarterGoalStreak, calcYearGoalStreak, calcGoalSuccessRate, calcLastNWeeks, calcWeekGoalHeatmap, calcLastNMonths, calcMonthGoalHeatmap, calcLastNQuarters, calcQuarterGoalHeatmap, calcLastNYears, calcYearGoalHeatmap } from "./lib/goalPeriods";
+import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQuarterGoalStreak, calcYearGoalStreak, calcGoalSuccessRate, calcLastNWeeks, calcWeekGoalHeatmap, calcLastNMonths, calcMonthGoalHeatmap, calcLastNQuarters, calcQuarterGoalHeatmap, calcLastNYears, calcYearGoalHeatmap, calcMonthlyGoalReminder, calcQuarterlyGoalReminder } from "./lib/goalPeriods";
 import { calcGoalExpiry } from "./lib/goalExpiry";
 import { calcDirectionBadge } from "./lib/direction";
 import { calcProjectsBadge, calcProjectMilestone } from "./lib/projects";
@@ -521,6 +521,60 @@ export default function App() {
       } catch { /* not available in browser dev mode */ }
     })();
   }, [data.weekGoal, data.weekGoalDone, data.weeklyReviewRemindDate, loaded, persist]);
+
+  // End-of-month goal review nudge — fires once per month in the last 2 calendar days at 18:00+.
+  // Triggers when monthGoal is set OR when no goal set (generic nudge to plan the next month).
+  // monthGoalRemindDate persists the guard so it fires only once per month-end even after restart.
+  // Design: date is persisted before the async send (same pattern as weeklyReviewRemindDate) to prevent duplicates.
+  useEffect(() => {
+    if (!loaded) return;
+    const now = new Date();
+    const today = now.toLocaleDateString("sv");
+    if (data.monthGoalRemindDate === today) return;
+    if (now.getHours() < 18) return;
+    // Last 2 days of the month: daysLeftInMonth ≤ 2
+    const todayMidnight = new Date(today + "T00:00:00");
+    const lastDayOfMonth = new Date(todayMidnight.getFullYear(), todayMidnight.getMonth() + 1, 0).getDate();
+    if (todayMidnight.getDate() < lastDayOfMonth - 1) return;
+    persist({ ...dataRef.current, monthGoalRemindDate: today });
+    (async () => {
+      try {
+        let ok = await isPermissionGranted();
+        if (!ok) { const perm = await requestPermission(); ok = perm === "granted"; }
+        if (!ok) return;
+        const msg = calcMonthlyGoalReminder(data.monthGoal, data.monthGoalDone);
+        sendNotification({ title: "Vision Widget", body: msg });
+      } catch { /* not available in browser dev mode */ }
+    })();
+  }, [data.monthGoal, data.monthGoalDone, data.monthGoalRemindDate, loaded, persist]);
+
+  // End-of-quarter goal review nudge — fires once per quarter in the last 3 calendar days at 18:00+.
+  // Triggers when quarterGoal is set OR when no goal set (generic nudge to plan the next quarter).
+  // quarterGoalRemindDate persists the guard so it fires only once per quarter-end even after restart.
+  // Design: date is persisted before the async send (same pattern as monthGoalRemindDate) to prevent duplicates.
+  useEffect(() => {
+    if (!loaded) return;
+    const now = new Date();
+    const today = now.toLocaleDateString("sv");
+    if (data.quarterGoalRemindDate === today) return;
+    if (now.getHours() < 18) return;
+    // Last 3 days of the quarter: quarter ends on Mar 31, Jun 30, Sep 30, Dec 31
+    const todayMidnight = new Date(today + "T00:00:00");
+    const qEndMonth = Math.ceil((todayMidnight.getMonth() + 1) / 3) * 3; // 3, 6, 9, or 12
+    const lastDayOfQuarter = new Date(todayMidnight.getFullYear(), qEndMonth, 0).getDate();
+    const isLastMonthOfQuarter = todayMidnight.getMonth() + 1 === qEndMonth;
+    if (!isLastMonthOfQuarter || todayMidnight.getDate() < lastDayOfQuarter - 2) return;
+    persist({ ...dataRef.current, quarterGoalRemindDate: today });
+    (async () => {
+      try {
+        let ok = await isPermissionGranted();
+        if (!ok) { const perm = await requestPermission(); ok = perm === "granted"; }
+        if (!ok) return;
+        const msg = calcQuarterlyGoalReminder(data.quarterGoal, data.quarterGoalDone);
+        sendNotification({ title: "Vision Widget", body: msg });
+      } catch { /* not available in browser dev mode */ }
+    })();
+  }, [data.quarterGoal, data.quarterGoalDone, data.quarterGoalRemindDate, loaded, persist]);
 
   // At-risk streak notification — fires once per app startup when habits are about to lose their streak.
   // "At risk" = streak > 0, last checked yesterday (midnight reset will zero the streak if not checked today).

--- a/src/lib/goalPeriods.test.ts
+++ b/src/lib/goalPeriods.test.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Tests for goalPeriods helpers — isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQuarterGoalStreak, calcYearGoalStreak, calcGoalSuccessRate, calcLastNWeeks, calcWeekGoalHeatmap, calcLastNMonths, calcMonthGoalHeatmap, calcLastNQuarters, calcQuarterGoalHeatmap, calcLastNYears, and calcYearGoalHeatmap
+// ABOUTME: Tests for goalPeriods helpers — isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQuarterGoalStreak, calcYearGoalStreak, calcGoalSuccessRate, calcLastNWeeks, calcWeekGoalHeatmap, calcLastNMonths, calcMonthGoalHeatmap, calcLastNQuarters, calcQuarterGoalHeatmap, calcLastNYears, calcYearGoalHeatmap, calcMonthlyGoalReminder, calcQuarterlyGoalReminder
 // ABOUTME: Covers year-boundary edge cases where ISO week year differs from calendar year
 
 import { describe, it, expect } from "vitest";
-import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQuarterGoalStreak, calcYearGoalStreak, calcGoalSuccessRate, calcLastNWeeks, calcWeekGoalHeatmap, calcLastNMonths, calcMonthGoalHeatmap, calcLastNQuarters, calcQuarterGoalHeatmap, calcLastNYears, calcYearGoalHeatmap } from "./goalPeriods";
+import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQuarterGoalStreak, calcYearGoalStreak, calcGoalSuccessRate, calcLastNWeeks, calcWeekGoalHeatmap, calcLastNMonths, calcMonthGoalHeatmap, calcLastNQuarters, calcQuarterGoalHeatmap, calcLastNYears, calcYearGoalHeatmap, calcMonthlyGoalReminder, calcQuarterlyGoalReminder } from "./goalPeriods";
 import type { GoalEntry } from "../types";
 
 describe("isoWeekStr", () => {
@@ -1067,5 +1067,89 @@ describe("calcYearGoalHeatmap", () => {
     const cur = result.years.find(y => y.year === CURRENT_Y)!;
     expect(cur.set).toBe(false);
     expect(cur.done).toBe(false);
+  });
+});
+
+const MONTH_GENERIC = "📅 월간 회고: 이번 달을 정리하고 다음 달 목표를 세워보세요!";
+
+describe("calcMonthlyGoalReminder", () => {
+  it("should return exact generic nudge when monthGoal is absent", () => {
+    expect(calcMonthlyGoalReminder(undefined, undefined)).toBe(MONTH_GENERIC);
+  });
+
+  it("should return exact generic nudge when monthGoal is empty string", () => {
+    // empty string trims to "" (falsy) → generic branch, not goal branch
+    expect(calcMonthlyGoalReminder("", undefined)).toBe(MONTH_GENERIC);
+  });
+
+  it("should return exact generic nudge when monthGoal is whitespace only", () => {
+    expect(calcMonthlyGoalReminder("   ", undefined)).toBe(MONTH_GENERIC);
+  });
+
+  it("should return exact generic nudge when done=true but monthGoal is absent", () => {
+    // stale persisted data: done=true but no goal text — generic branch takes precedence
+    expect(calcMonthlyGoalReminder(undefined, true)).toBe(MONTH_GENERIC);
+  });
+
+  it("should return exact not-done message when goal is set but monthGoalDone is absent", () => {
+    expect(calcMonthlyGoalReminder("매일 운동 20회", undefined))
+      .toBe("📅 월간 회고: '매일 운동 20회' — 이번 달을 마무리해보세요.");
+  });
+
+  it("should return exact not-done message when goal is set and monthGoalDone is false", () => {
+    expect(calcMonthlyGoalReminder("블로그 5편", false))
+      .toBe("📅 월간 회고: '블로그 5편' — 이번 달을 마무리해보세요.");
+  });
+
+  it("should return exact done message when monthGoalDone is true", () => {
+    expect(calcMonthlyGoalReminder("신규 기능 출시", true))
+      .toBe("✅ 월간 회고: '신규 기능 출시' 달성! 다음 달 목표도 세워보세요.");
+  });
+
+  it("should trim whitespace from monthGoal in message", () => {
+    expect(calcMonthlyGoalReminder("  PR 완료  ", false))
+      .toBe("📅 월간 회고: 'PR 완료' — 이번 달을 마무리해보세요.");
+  });
+});
+
+const QUARTER_GENERIC = "📋 분기 회고: 이번 분기를 정리하고 다음 분기 목표를 세워보세요!";
+
+describe("calcQuarterlyGoalReminder", () => {
+  it("should return exact generic nudge when quarterGoal is absent", () => {
+    expect(calcQuarterlyGoalReminder(undefined, undefined)).toBe(QUARTER_GENERIC);
+  });
+
+  it("should return exact generic nudge when quarterGoal is empty string", () => {
+    // empty string trims to "" (falsy) → generic branch, not goal branch
+    expect(calcQuarterlyGoalReminder("", undefined)).toBe(QUARTER_GENERIC);
+  });
+
+  it("should return exact generic nudge when quarterGoal is whitespace only", () => {
+    expect(calcQuarterlyGoalReminder("   ", undefined)).toBe(QUARTER_GENERIC);
+  });
+
+  it("should return exact generic nudge when done=true but quarterGoal is absent", () => {
+    // stale persisted data: done=true but no goal text — generic branch takes precedence
+    expect(calcQuarterlyGoalReminder(undefined, true)).toBe(QUARTER_GENERIC);
+  });
+
+  it("should return exact not-done message when goal is set but quarterGoalDone is absent", () => {
+    expect(calcQuarterlyGoalReminder("Q1 매출 목표 달성", undefined))
+      .toBe("📋 분기 회고: 'Q1 매출 목표 달성' — 이번 분기를 마무리해보세요.");
+  });
+
+  it("should return exact not-done message when goal is set and quarterGoalDone is false", () => {
+    expect(calcQuarterlyGoalReminder("신제품 론칭", false))
+      .toBe("📋 분기 회고: '신제품 론칭' — 이번 분기를 마무리해보세요.");
+  });
+
+  it("should return exact done message when quarterGoalDone is true", () => {
+    expect(calcQuarterlyGoalReminder("팀 확장 3명", true))
+      .toBe("✅ 분기 회고: '팀 확장 3명' 달성! 다음 분기 목표도 세워보세요.");
+  });
+
+  it("should trim whitespace from quarterGoal in message", () => {
+    expect(calcQuarterlyGoalReminder("  분기 목표  ", false))
+      .toBe("📋 분기 회고: '분기 목표' — 이번 분기를 마무리해보세요.");
   });
 });

--- a/src/lib/goalPeriods.ts
+++ b/src/lib/goalPeriods.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Pure helpers for goal period key generation — ISO week string, quarter string, goal streaks, success rate, and goal heatmaps
-// ABOUTME: Exported for unit testing; used by App.tsx to anchor goal expiry, date stamps, streak display, history panels, and goal heatmap dot rows
+// ABOUTME: Pure helpers for goal period key generation — ISO week string, quarter string, goal streaks, success rate, goal heatmaps, and end-of-period review reminders
+// ABOUTME: Exported for unit testing; used by App.tsx to anchor goal expiry, date stamps, streak display, history panels, goal heatmap dot rows, and monthly/quarterly review nudges
 
 import type { GoalEntry } from "../types";
 
@@ -375,4 +375,40 @@ export function calcYearGoalHeatmap(
   const setCount = years.filter(y => y.set).length;
   const doneCount = years.filter(y => y.set && y.done).length;
   return { years, setCount, doneCount };
+}
+
+// Returns the desktop notification body for the end-of-month goal review nudge.
+// Three variants based on monthGoal state:
+//   - no goal (absent/empty/whitespace): generic "review + plan next month" nudge
+//   - goal set, not done (monthGoalDone absent or false): includes goal text, prompts reflection
+//   - goal set, done (monthGoalDone === true): congratulates achievement, nudges next-month planning
+// Hour/day guards (last 2 days of the month, getHours() >= 18) live in the caller (App.tsx useEffect).
+// Callers check monthGoalRemindDate before invoking to ensure once-per-month-end delivery.
+// Exported for unit testing; pure function with no side effects.
+export function calcMonthlyGoalReminder(
+  monthGoal: string | undefined,
+  monthGoalDone: boolean | undefined,
+): string {
+  const trimmed = monthGoal?.trim();
+  if (!trimmed) return "📅 월간 회고: 이번 달을 정리하고 다음 달 목표를 세워보세요!";
+  if (monthGoalDone) return `✅ 월간 회고: '${trimmed}' 달성! 다음 달 목표도 세워보세요.`;
+  return `📅 월간 회고: '${trimmed}' — 이번 달을 마무리해보세요.`;
+}
+
+// Returns the desktop notification body for the end-of-quarter goal review nudge.
+// Three variants based on quarterGoal state:
+//   - no goal (absent/empty/whitespace): generic "review + plan next quarter" nudge
+//   - goal set, not done (quarterGoalDone absent or false): includes goal text, prompts reflection
+//   - goal set, done (quarterGoalDone === true): congratulates achievement, nudges next-quarter planning
+// Hour/day guards (last 3 days of the quarter, getHours() >= 18) live in the caller (App.tsx useEffect).
+// Callers check quarterGoalRemindDate before invoking to ensure once-per-quarter-end delivery.
+// Exported for unit testing; pure function with no side effects.
+export function calcQuarterlyGoalReminder(
+  quarterGoal: string | undefined,
+  quarterGoalDone: boolean | undefined,
+): string {
+  const trimmed = quarterGoal?.trim();
+  if (!trimmed) return "📋 분기 회고: 이번 분기를 정리하고 다음 분기 목표를 세워보세요!";
+  if (quarterGoalDone) return `✅ 분기 회고: '${trimmed}' 달성! 다음 분기 목표도 세워보세요.`;
+  return `📋 분기 회고: '${trimmed}' — 이번 분기를 마무리해보세요.`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,8 @@ export interface WidgetData {
   pomodoroEveningRemindDate?: string;  // YYYY-MM-DD date when the evening pomodoro goal-gap nudge was sent; absent = not sent
   habitMilestoneApproachDate?: string; // YYYY-MM-DD date when the habit milestone approach nudge was sent; absent = not sent
   weeklyReviewRemindDate?: string;     // YYYY-MM-DD (Sunday) when the weekly review nudge was last sent; absent = not sent
+  monthGoalRemindDate?: string;        // YYYY-MM-DD when the end-of-month goal review nudge was last sent; absent = not sent
+  quarterGoalRemindDate?: string;      // YYYY-MM-DD when the end-of-quarter goal review nudge was last sent; absent = not sent
   weekGoalHistory?: GoalEntry[];   // rolling log of past weekly goals; newest last; capped at 8 entries; absent = no history
   monthGoalHistory?: GoalEntry[];  // rolling log of past monthly goals; newest last; capped at 12 entries; absent = no history
   quarterGoalHistory?: GoalEntry[]; // rolling log of past quarterly goals; newest last; capped at 8 entries; absent = no history


### PR DESCRIPTION
## Summary
- `calcMonthlyGoalReminder` — 월말 2일 전·당일 18시 이후 데스크탑 알림 (3-variant)
- `calcQuarterlyGoalReminder` — 분기말 3일 전·당일 18시 이후 데스크탑 알림 (3-variant)
- 주간 리뷰 알림(36d5141)과 동일한 persist-before-send 패턴, `monthGoalRemindDate` / `quarterGoalRemindDate` 가드 필드

## Changes
- `src/lib/goalPeriods.ts` — 순수 함수 2개 추가, ABOUTME 업데이트
- `src/lib/goalPeriods.test.ts` — `toBe` 정확 단언 기반 16 테스트 추가
- `src/types.ts` — `monthGoalRemindDate`, `quarterGoalRemindDate` 필드 추가
- `src-tauri/src/lib.rs` — Rust struct 필드 + default() + sanitize 경로 추가
- `src/App.tsx` — useEffect 2개 + import 업데이트

## 선택 근거
주간 리뷰 알림이 있지만 월간·분기 목표 마감 알림이 없었음. "Personal Command Center" 목표 달성 지원 강화.

---
_자율 개발 에이전트가 생성한 PR_