### PR TITLE
feat(insight): month_goal_streak 인사이트 추가 + todayIsWeakHabitDay 와이어업

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { useGitHubSync } from "./hooks/useGitHubSync";
 import { fetchRepoData } from "./lib/github";
 import { totalDaysInMonth, totalDaysInQuarter, totalDaysInYear, periodElapsedFraction, daysLeftInWeek, daysLeftInMonth, daysLeftInQuarter, daysLeftInYear, calcLastNDays } from "./lib/datePeriods";
 import { calcIntentionStreak, calcIntentionWeek, calcIntentionWeekTrend, calcIntentionDoneNotify, calcMorningIntentionReminder, calcIntentionEveningReminder } from "./lib/intention";
-import { calcHabitsWeekRate, calcHabitsWeekTrend, calcHabitsBadge, calcPerfectDayStreak, calcEveningHabitReminder, calcHabitMilestoneApproachNotify, calcWeeklyReviewReminder, calcPerfectDayMilestoneNotify, calcWeeklyHabitReport } from "./lib/habits";
+import { calcHabitsWeekRate, calcHabitsWeekTrend, calcHabitsBadge, calcPerfectDayStreak, calcEveningHabitReminder, calcHabitMilestoneApproachNotify, calcWeeklyReviewReminder, calcPerfectDayMilestoneNotify, calcWeeklyHabitReport, calcDayOfWeekHabitRates, calcWeakDayOfWeek } from "./lib/habits";
 import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQuarterGoalStreak, calcYearGoalStreak, calcGoalSuccessRate, calcLastNWeeks, calcWeekGoalHeatmap, calcLastNMonths, calcMonthGoalHeatmap, calcLastNQuarters, calcQuarterGoalHeatmap, calcLastNYears, calcYearGoalHeatmap, calcMonthlyGoalReminder, calcQuarterlyGoalReminder, calcYearlyGoalReminder, calcGoalCompletionNotify, calcWeeklyGoalMorningReminder, calcWeeklyGoalReport, calcMonthlyGoalReport, calcQuarterlyGoalReport, calcYearlyGoalReport } from "./lib/goalPeriods";
 import { calcGoalExpiry } from "./lib/goalExpiry";
 import { calcDirectionBadge } from "./lib/direction";
@@ -1220,6 +1220,10 @@ export default function App() {
     todayStr,
     data.intentionHistory ?? [],
   );
+  // last28Days: 4-week window used for per-weekday habit rate (calcDayOfWeekHabitRates).
+  // Declared here (before calcTodayInsight) so todayIsWeakHabitDay can use it inside the call.
+  // The render-phase last7Days/last14Days consts below serve the heatmap/badge subsystems.
+  const last28Days = calcLastNDays(todayStr, 28);
   // todayInsight: single most actionable context-aware insight for the Clock badge
   const todayInsight = calcTodayInsight({
     habits: habitsArr,
@@ -1253,8 +1257,26 @@ export default function App() {
       (data.weekGoalHistory ?? []).filter(e => e.done === true),
       renderDate,
     ) - 1),
+    // Past consecutive done months (excludes current month): mirrors weekGoalPastDoneStreak pattern.
+    // calcMonthGoalStreak is designed to count "months a goal was SET"; by filtering history to
+    // done===true entries only we repurpose it to count "months a goal was ACHIEVED" — the same
+    // intentional reuse as weekGoalPastDoneStreak (see App.tsx:1250). Subtract 1 to exclude the
+    // current month (which by construction is not yet done when this insight fires).
+    monthGoalPastDoneStreak: Math.max(0, calcMonthGoalStreak(
+      data.monthGoal,
+      data.monthGoalDate,
+      (data.monthGoalHistory ?? []).filter(e => e.done === true),
+      renderDate,
+    ) - 1),
     pomodoroGoalStreak,
     intentionConsecutiveDays,
+    // todayIsWeakHabitDay: true when today's weekday is the user's historically lowest habit-completion day.
+    // Uses last28Days (4 full weeks) so each weekday has exactly 4 data points — well above MIN_DOW_APPEARANCES=2.
+    todayIsWeakHabitDay: (() => {
+      const rates = calcDayOfWeekHabitRates(habitsArr, last28Days);
+      const weakestDow = calcWeakDayOfWeek(rates);
+      return weakestDow !== null && new Date(todayStr + "T00:00:00").getDay() === weakestDow;
+    })(),
   });
   // Persist today's momentum score whenever it changes — upserts into rolling 7-day history.
   // Uses dataRef.current (not `data`) to avoid stale closure overwriting concurrent changes

--- a/src/lib/insight.test.ts
+++ b/src/lib/insight.test.ts
@@ -3591,6 +3591,102 @@ describe("calcTodayInsight — goal_streak (priority 10.75, morning, past done w
   });
 });
 
+// ── month_goal_streak (priority 10.77, after goal_streak, before project_ahead) ──────
+describe("calcTodayInsight — month_goal_streak (priority 10.77, morning, past done month streak)", () => {
+  // Base params: morning, no higher-priority triggers, month goal set but not done
+  const base = {
+    habits: [],
+    todayStr: TOMORROW, // 2024-01-16 (Tuesday, not 1st of month → period_start doesn't fire)
+    nowHour: 9, // morning
+    todayIntentionDate: TOMORROW,
+    sessionsToday: 0,
+    sessionGoal: undefined,
+    habitsAllDoneDate: undefined,
+    weekGoal: "이번 주 목표",
+    weekGoalDone: false as boolean | undefined,
+    daysLeftWeek: 5,
+    monthGoal: "이번 달 목표",
+    monthGoalDone: false as boolean | undefined,
+    daysLeftMonth: 10, // avoids goal_midpoint (fires at 15/16) and goal_expiry (fires at ≤2)
+  };
+
+  it("shouldReturnMonthGoalStreakWhenPastDoneStreakIs1", () => {
+    const result = calcTodayInsight({ ...base, monthGoalPastDoneStreak: 1 });
+    expect(result).not.toBeNull();
+    expect(result!.level).toBe("success");
+    expect(result!.text).toContain("1개월 연속");
+    expect(result!.text).toContain("이번 달도");
+  });
+
+  it("shouldReturnMonthGoalStreakWhenPastDoneStreakIs3", () => {
+    const result = calcTodayInsight({ ...base, monthGoalPastDoneStreak: 3 });
+    expect(result).not.toBeNull();
+    expect(result!.level).toBe("success");
+    expect(result!.text).toContain("3개월 연속");
+  });
+
+  it("shouldNotReturnMonthGoalStreakWhenPastDoneStreakIs0", () => {
+    const result = calcTodayInsight({ ...base, monthGoalPastDoneStreak: 0 });
+    expect(result).toBeNull();
+  });
+
+  it("shouldNotReturnMonthGoalStreakWhenPastDoneStreakAbsent", () => {
+    const result = calcTodayInsight({ ...base, monthGoalPastDoneStreak: undefined });
+    expect(result).toBeNull();
+  });
+
+  it("shouldNotReturnMonthGoalStreakWhenMonthGoalAlreadyDone", () => {
+    // monthGoalDone=true → goal_done (10.7) fires instead (daysLeftMonth=10 > 2)
+    const result = calcTodayInsight({ ...base, monthGoalDone: true, daysLeftMonth: 10, monthGoalPastDoneStreak: 2 });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("월간 목표 달성"); // goal_done wins
+    expect(result!.text).not.toContain("개월 연속 달성 중");
+  });
+
+  it("shouldNotReturnMonthGoalStreakWhenNotMorning", () => {
+    const result = calcTodayInsight({ ...base, nowHour: 14, monthGoalPastDoneStreak: 2 });
+    expect(result).toBeNull();
+  });
+
+  it("shouldReturnMonthGoalStreakAtHour11ButNotAtHour12", () => {
+    const at11 = calcTodayInsight({ ...base, nowHour: 11, monthGoalPastDoneStreak: 1 });
+    expect(at11).not.toBeNull();
+    expect(at11!.text).toContain("개월 연속 달성 중");
+
+    const at12 = calcTodayInsight({ ...base, nowHour: 12, monthGoalPastDoneStreak: 1 });
+    expect(at12).toBeNull();
+  });
+
+  it("shouldNotReturnMonthGoalStreakWhenNoMonthGoal", () => {
+    const result = calcTodayInsight({ ...base, monthGoal: undefined, monthGoalPastDoneStreak: 2 });
+    expect(result).toBeNull();
+  });
+
+  it("shouldGoalStreakFireBeforeMonthGoalStreak", () => {
+    // goal_streak (10.75) fires before month_goal_streak (10.77)
+    const result = calcTodayInsight({
+      ...base,
+      weekGoalPastDoneStreak: 2,
+      monthGoalPastDoneStreak: 3,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("주 연속 달성 중"); // weekly goal_streak (10.75) wins
+  });
+
+  it("shouldMonthGoalStreakFireBeforeProjectAhead", () => {
+    // month_goal_streak (10.77) fires before project_ahead (10.8)
+    const result = calcTodayInsight({
+      ...base,
+      monthGoalPastDoneStreak: 2,
+      projects: [
+        { name: "앞서가는프로젝트", status: "active", deadline: "2024-02-22", createdDate: DAYS_7_AGO, progress: 70, isFocus: true },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("개월 연속 달성 중"); // month_goal_streak wins over project_ahead
+  });
+});
+
 // ── project_near_completion (priority 10.85, after project_ahead, before personal_best) ────
 describe("calcTodayInsight — project_near_completion (priority 10.85, after project_ahead)", () => {
   const base = {

--- a/src/lib/insight.ts
+++ b/src/lib/insight.ts
@@ -1,5 +1,5 @@
 // ABOUTME: calcTodayInsight — context-aware daily insight engine for the Clock badge
-// ABOUTME: Priority chain: streak risk > deadline critical > milestone > perfect day > intention > period_start (year/quarter/month/week) > no_focus_project > weak_day_ahead (morning, historically low-completion weekday) > pomodoro_last_one > pomodoro_goal_streak (≥2 consecutive past goal days) > pomodoro_goal_reached > deadline soon > project behind (≥20% gap) > goal expiry (week≤2d > month≤2d > quarter≤7d > year≤14d) > goal midpoint (Thu/mid-month/mid-quarter/mid-year, cascade year>quarter>month>week) > momentum decline > project stale > streak recession (≥7d broken yesterday) > habit consecutive miss (≥3d) > almost perfect day (≥14h, 1–2 habits left) > momentum rise > goal done (year>quarter>month>week, daysLeft above expiry threshold) > goal streak (past ≥1 consecutive done weeks, morning only) > project ahead (≥20% ahead of schedule) > project near completion (progress ≥90%) > personal best > habit target near (user-defined targetStreak within 2 days) > intention streak (≥7d consecutive intention-setting)
+// ABOUTME: Priority chain: streak risk > deadline critical > milestone > perfect day > intention > period_start (year/quarter/month/week) > no_focus_project > weak_day_ahead (morning, historically low-completion weekday) > pomodoro_last_one > pomodoro_goal_streak (≥2 consecutive past goal days) > pomodoro_goal_reached > deadline soon > project behind (≥20% gap) > goal expiry (week≤2d > month≤2d > quarter≤7d > year≤14d) > goal midpoint (Thu/mid-month/mid-quarter/mid-year, cascade year>quarter>month>week) > momentum decline > project stale > streak recession (≥7d broken yesterday) > habit consecutive miss (≥3d) > almost perfect day (≥14h, 1–2 habits left) > momentum rise > goal done (year>quarter>month>week, daysLeft above expiry threshold) > goal streak (past ≥1 consecutive done weeks, morning only) > month goal streak (past ≥1 consecutive done months, morning only) > project ahead (≥20% ahead of schedule) > project near completion (progress ≥90%) > personal best > habit target near (user-defined targetStreak within 2 days) > intention streak (≥7d consecutive intention-setting)
 
 import { getUpcomingMilestone } from "./habits";
 import { calcMomentumTrend } from "./momentum";
@@ -80,6 +80,12 @@ interface InsightParams {
    * Absent/false = today is not a weak day or insufficient data; no nudge is shown.
    */
   todayIsWeakHabitDay?: boolean;
+  /**
+   * Number of consecutive PAST calendar months (excluding current) where the monthly goal was marked done.
+   * A value ≥ 1 with monthGoalDone === false triggers a morning streak-encouragement nudge.
+   * Absent/undefined = no streak data available.
+   */
+  monthGoalPastDoneStreak?: number;
 }
 
 // Habit streak milestones at which a personal-best celebration is shown (mirrors getUpcomingMilestone targets).
@@ -131,7 +137,7 @@ function daysUntil(deadline: string, todayStr: string): number | null {
 }
 
 // Returns the single most relevant actionable insight for the user right now, or null if nothing notable.
-// Priority order: streak_at_risk > deadline_critical > milestone_near > perfect_day > intention_missing > period_start > no_focus_project > weak_day_ahead > pomodoro_last_one > pomodoro_goal_streak > pomodoro_goal_reached > deadline_soon > goal_expiry > momentum_decline > project_stale > streak_recession > habit_consecutive_miss > almost_perfect_day > momentum_rise > goal_done > goal_streak > project_ahead > project_near_completion > personal_best > habit_target_near > intention_streak.
+// Priority order: streak_at_risk > deadline_critical > milestone_near > perfect_day > intention_missing > period_start > no_focus_project > weak_day_ahead > pomodoro_last_one > pomodoro_goal_streak > pomodoro_goal_reached > deadline_soon > goal_expiry > momentum_decline > project_stale > streak_recession > habit_consecutive_miss > almost_perfect_day > momentum_rise > goal_done > goal_streak > month_goal_streak > project_ahead > project_near_completion > personal_best > habit_target_near > intention_streak.
 export function calcTodayInsight(params: InsightParams): TodayInsight | null {
   const {
     habits, todayStr, nowHour, todayIntentionDate, sessionsToday, sessionGoal, habitsAllDoneDate, projects,
@@ -144,6 +150,7 @@ export function calcTodayInsight(params: InsightParams): TodayInsight | null {
     pomodoroGoalStreak,
     intentionConsecutiveDays,
     todayIsWeakHabitDay,
+    monthGoalPastDoneStreak,
   } = params;
 
   // 1. Streak at risk: evening (≥ 18h) + high streak (≥ 7) + not yet checked today
@@ -416,6 +423,15 @@ export function calcTodayInsight(params: InsightParams): TodayInsight | null {
   if (nowHour < 12 && weekGoal && !weekGoalDone && weekGoalPastDoneStreak != null && weekGoalPastDoneStreak >= 1) {
     const streak = weekGoalPastDoneStreak;
     return { text: `✅ 주간 목표 ${streak}주 연속 달성 중! 이번 주도 화이팅`, level: "success" };
+  }
+
+  // 10.77. Month goal streak: monthly goal achieved for ≥1 consecutive past month AND not yet done this month.
+  // Morning-only (< 12h) motivational nudge for consistent monthly goal achievers.
+  // Placed after goal_streak (10.75) so weekly momentum takes precedence; placed before project_ahead (10.8).
+  // Uses past-done streak (excluding current month) so it never fires when goal_done (10.7) would fire.
+  if (nowHour < 12 && monthGoal && !monthGoalDone && monthGoalPastDoneStreak != null && monthGoalPastDoneStreak >= 1) {
+    const streak = monthGoalPastDoneStreak;
+    return { text: `✅ 월간 목표 ${streak}개월 연속 달성 중! 이번 달도 화이팅`, level: "success" };
   }
 
   // 10.8. Project ahead of schedule: active/in-progress project >7 days from deadline with ≥20% schedule surplus.


### PR DESCRIPTION
## Summary
- `month_goal_streak` 인사이트 추가 (priority 10.77): 연속 월간 목표 달성 중인 사용자에게 아침 격려 배지 표시
- `todayIsWeakHabitDay` App.tsx 와이어업: insight.ts에 구현됐지만 App.tsx에서 `undefined`로 전달되어 실제로 동작하지 않던 버그 수정

## Changes
- `src/lib/insight.ts`: `InsightParams.monthGoalPastDoneStreak` 추가, priority 10.77 `month_goal_streak` 케이스 추가
- `src/lib/insight.test.ts`: `month_goal_streak` 테스트 9개 추가 (priority 경계 케이스 포함)
- `src/App.tsx`: `calcDayOfWeekHabitRates` + `calcWeakDayOfWeek` 임포트, `last28Days` const 추출, `todayIsWeakHabitDay` + `monthGoalPastDoneStreak` 계산 추가

## 선택 근거
- `weekGoalPastDoneStreak`(10.75) 패턴과 동일한 구조로 월간 버전 구현 — 일관성 있는 설계
- `weak_day_ahead` 인사이트(6.8)는 이미 완전히 구현되고 테스트됐지만 App.tsx 와이어업이 누락되어 실제로 동작하지 않았음
- 1625 → 1635 테스트 (+10), 빌드 성공

---
_자율 개발 에이전트가 생성한 PR_