### PR TITLE
feat(insight): pomodoro_week_record — 주간 포모도로 신기록 배지 추가 (priority 7.495)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import { isoWeekStr, quarterStr, calcWeekGoalStreak, calcMonthGoalStreak, calcQu
 import { calcGoalExpiry } from "./lib/goalExpiry";
 import { calcDirectionBadge } from "./lib/direction";
 import { calcProjectsBadge, calcProjectMilestone, calcProjectCompletionNotify, calcProjectPomodoroMilestone } from "./lib/projects";
-import { calcTodaySessionCount, updatePomodoroHistory, calcPomodoroMorningReminder, calcPomodoroEveningReminder, calcPomodoroLifetimeMilestone, calcWeeklyPomodoroReport, calcPomodoroGoalStreak, calcFocusStreak, calcPomodoroRecentAvg } from "./lib/pomodoro";
+import { calcTodaySessionCount, updatePomodoroHistory, calcPomodoroMorningReminder, calcPomodoroEveningReminder, calcPomodoroLifetimeMilestone, calcWeeklyPomodoroReport, calcPomodoroGoalStreak, calcFocusStreak, calcPomodoroRecentAvg, calcPomodoroWeekRecord } from "./lib/pomodoro";
 import { calcDailyScore, updateMomentumHistory, calcMomentumStreak, calcMomentumWeekAvg, calcMomentumEveningDigest, calcWeeklyMomentumReport } from "./lib/momentum";
 import { calcTodayInsight } from "./lib/insight";
 import { Clock } from "./components/Clock";
@@ -1240,6 +1240,9 @@ export default function App() {
   // excluded inside calcPomodoroRecentAvg via the todayStr filter — this exclusion is load-bearing.
   // Passed to calcTodayInsight for the pomodoro_today_above_avg badge (priority 10.45).
   const pomodoroRecentAvg = calcPomodoroRecentAvg(data.pomodoroHistory ?? [], todayStr);
+  // pomodoroWeekRecord: current ISO-week total when it beats the same-length prev-week window, or false.
+  // Passed to calcTodayInsight for the pomodoro_week_record badge (priority 7.495).
+  const pomodoroWeekRecord = calcPomodoroWeekRecord(data.pomodoroHistory ?? [], todayStr);
   // todayInsight: single most actionable context-aware insight for the Clock badge
   const todayInsight = calcTodayInsight({
     habits: habitsArr,
@@ -1295,6 +1298,7 @@ export default function App() {
     pomodoroGoalStreak,
     pomodoroSessionBest,
     pomodoroRecentAvg,
+    pomodoroWeekRecord,
     intentionConsecutiveDays,
     focusStreak,
     // todayIsWeakHabitDay / todayIsBestHabitDay: derived from the same per-weekday rates computed once.

--- a/src/lib/insight.test.ts
+++ b/src/lib/insight.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for calcTodayInsight — context-aware daily insight surfacing
-// ABOUTME: Covers all insight types and their priority ordering (including no_focus_project, weak_day_ahead, best_day_ahead, pomodoro_goal_streak, pomodoro_goal_reached, momentum_decline + momentum_rise, open_issues, intention_done, pomodoro_today_above_avg)
+// ABOUTME: Covers all insight types and their priority ordering (including no_focus_project, weak_day_ahead, best_day_ahead, pomodoro_goal_streak, pomodoro_goal_reached, pomodoro_week_record, momentum_decline + momentum_rise, open_issues, intention_done, pomodoro_today_above_avg)
 
 import { describe, it, expect } from "vitest";
 import { calcTodayInsight } from "./insight";
@@ -6177,4 +6177,76 @@ describe("calcTodayInsight — project_context_switching (priority 10.05, betwee
     });
   });
 
+});
+
+describe("calcTodayInsight — pomodoro_week_record (priority 7.495, between pomodoro_day_record and pomodoro_goal_reached)", () => {
+  // Base: afternoon, intention set, no habits, no goal, no competing insights.
+  const base = () => ({
+    habits: [] as Array<{ name: string; streak: number; lastChecked?: string; bestStreak?: number }>,
+    todayStr: TODAY,
+    nowHour: 14,
+    todayIntentionDate: TODAY,
+    sessionsToday: 3,
+    sessionGoal: undefined as number | undefined,
+    habitsAllDoneDate: undefined as string | undefined,
+  });
+
+  it("shouldReturnWeekRecordWhenPomodoroWeekRecordIsPositiveNumber", () => {
+    const result = calcTodayInsight({ ...base(), pomodoroWeekRecord: 7 });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("주간 신기록");
+    expect(result!.text).toContain("7");
+    expect(result!.level).toBe("success");
+  });
+
+  it("shouldNotReturnWeekRecordWhenPomodoroWeekRecordIsFalse", () => {
+    const result = calcTodayInsight({ ...base(), pomodoroWeekRecord: false });
+    expect(result?.text ?? "").not.toContain("주간 신기록");
+  });
+
+  it("shouldNotReturnWeekRecordWhenPomodoroWeekRecordAbsent", () => {
+    const result = calcTodayInsight({ ...base() });
+    expect(result?.text ?? "").not.toContain("주간 신기록");
+  });
+
+  it("shouldBePreemptedByPomodoroDayRecord", () => {
+    // day_record (7.49) fires before week_record (7.495) when both conditions are met.
+    // sessionsToday=6 > pomodoroSessionBest=5 → day record fires; week record not shown.
+    const result = calcTodayInsight({
+      ...base(), sessionsToday: 6, pomodoroSessionBest: 5, pomodoroWeekRecord: 7,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("오늘 포모도로 신기록"); // day record wins
+    expect(result!.text).not.toContain("주간 신기록");
+  });
+
+  it("shouldFireWhenDayRecordConditionNotMet", () => {
+    // sessionsToday=4 equals pomodoroSessionBest=4 → day record does NOT fire (not strictly greater).
+    // week record fires instead.
+    const result = calcTodayInsight({
+      ...base(), sessionsToday: 4, pomodoroSessionBest: 4, pomodoroWeekRecord: 9,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("주간 신기록");
+    expect(result!.text).toContain("9");
+  });
+
+  it("shouldFireBeforeGoalReachedWhenBothConditionsMet", () => {
+    // week_record (7.495) fires before goal_reached (7.5) when both are true.
+    const result = calcTodayInsight({
+      ...base(), sessionsToday: 4, sessionGoal: 4, pomodoroWeekRecord: 9,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("주간 신기록"); // week record preempts goal_reached
+    expect(result!.text).not.toContain("목표 달성");
+  });
+
+  it("shouldFireGoalReachedWhenNoWeekRecord", () => {
+    // When week record is absent/false, goal_reached fires as expected.
+    const result = calcTodayInsight({
+      ...base(), sessionsToday: 4, sessionGoal: 4, pomodoroWeekRecord: false,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("목표 달성");
+  });
 });

--- a/src/lib/insight.ts
+++ b/src/lib/insight.ts
@@ -1,5 +1,5 @@
 // ABOUTME: calcTodayInsight — context-aware daily insight engine for the Clock badge
-// ABOUTME: Priority chain: streak risk > deadline critical > ci_failure (active project CI broken) > milestone > open_prs (active project has open PRs awaiting review) > github_drought (active project >7 days since last commit) > open_issues (active project ≥5 open GitHub issues) > perfect day > intention_done (today's intention marked done) > intention > period_start (year/quarter/month/week) > no_focus_project > weak_day_ahead (morning, historically low-completion weekday) > best_day_ahead (morning, historically high-completion weekday ≥80%) > habit_first_check_in (streak=1, bestStreak≤1, checked today = brand-new habit first step) > habit_comeback (bestStreak≥14, streak 3+, checked today = recovering from broken long streak) > pomodoro_last_one > focus_streak_milestone (7/14/30 consecutive focus days, sessionsToday > 0) > pomodoro_goal_streak (≥2 consecutive past goal days) > pomodoro_day_record (today's session count beats all-time single-day best) > pomodoro_goal_reached > deadline soon > project behind (≥20% gap) > goal expiry (week≤2d > month≤2d > quarter≤7d > year≤14d) > goal midpoint (Thu/mid-month/mid-quarter/mid-year, cascade year>quarter>month>week) > momentum decline > project stale > project context switching (≥4 active projects all focused within 7 days) > streak recession (≥7d broken yesterday) > habit consecutive miss (≥3d) > almost perfect day (≥14h, 1–2 habits left) > pomodoro_today_above_avg (sessionsToday ≥ rolling average +2) > momentum rise > goal done (year>quarter>month>week, daysLeft above expiry threshold) > goal streak (past ≥1 consecutive done weeks, morning only) > month_goal_streak (past ≥2 consecutive done months, morning only) > quarter_goal_streak (past ≥2 consecutive done quarters, morning only) > project ahead (≥20% ahead of schedule) > project near completion (progress ≥90%) > project forecast (at-current-pace completion date for on-track projects with deadline >7d) > personal best > habit target near (user-defined targetStreak within 2 days) > intention streak (≥7d consecutive intention-setting)
+// ABOUTME: Priority chain: streak risk > deadline critical > ci_failure (active project CI broken) > milestone > open_prs (active project has open PRs awaiting review) > github_drought (active project >7 days since last commit) > open_issues (active project ≥5 open GitHub issues) > perfect day > intention_done (today's intention marked done) > intention > period_start (year/quarter/month/week) > no_focus_project > weak_day_ahead (morning, historically low-completion weekday) > best_day_ahead (morning, historically high-completion weekday ≥80%) > habit_first_check_in (streak=1, bestStreak≤1, checked today = brand-new habit first step) > habit_comeback (bestStreak≥14, streak 3+, checked today = recovering from broken long streak) > pomodoro_last_one > focus_streak_milestone (7/14/30 consecutive focus days, sessionsToday > 0) > pomodoro_goal_streak (≥2 consecutive past goal days) > pomodoro_day_record (today's session count beats all-time single-day best) > pomodoro_week_record (current ISO-week total beats same-length prev-week window) > pomodoro_goal_reached > deadline soon > project behind (≥20% gap) > goal expiry (week≤2d > month≤2d > quarter≤7d > year≤14d) > goal midpoint (Thu/mid-month/mid-quarter/mid-year, cascade year>quarter>month>week) > momentum decline > project stale > project context switching (≥4 active projects all focused within 7 days) > streak recession (≥7d broken yesterday) > habit consecutive miss (≥3d) > almost perfect day (≥14h, 1–2 habits left) > pomodoro_today_above_avg (sessionsToday ≥ rolling average +2) > momentum rise > goal done (year>quarter>month>week, daysLeft above expiry threshold) > goal streak (past ≥1 consecutive done weeks, morning only) > month_goal_streak (past ≥2 consecutive done months, morning only) > quarter_goal_streak (past ≥2 consecutive done quarters, morning only) > project ahead (≥20% ahead of schedule) > project near completion (progress ≥90%) > project forecast (at-current-pace completion date for on-track projects with deadline >7d) > personal best > habit target near (user-defined targetStreak within 2 days) > intention streak (≥7d consecutive intention-setting)
 
 import { getUpcomingMilestone } from "./habits";
 import { calcMomentumTrend } from "./momentum";
@@ -122,6 +122,13 @@ interface InsightParams {
    */
   focusStreak?: number;
   /**
+   * Current ISO-week session total when it strictly exceeds the same-length window of the previous
+   * ISO week (Mon–today vs. Mon–same-weekday-last-week), or false when not a record.
+   * Computed by calcPomodoroWeekRecord(pomodoroHistory, todayStr) in App.tsx.
+   * A positive number triggers a pomodoro_week_record badge showing the total; false/absent = no badge.
+   */
+  pomodoroWeekRecord?: number | false;
+  /**
    * Average pomodoro sessions per calendar day across all past history entries (today excluded).
    * Derived from the rolling 14-day pomodoroHistory; covers up to 13 past days — not a strict 7-day window.
    * Computed by calcPomodoroRecentAvg(pomodoroHistory, todayStr) in App.tsx.
@@ -212,7 +219,7 @@ function daysUntil(deadline: string, todayStr: string): number | null {
 }
 
 // Returns the single most relevant actionable insight for the user right now, or null if nothing notable.
-// Priority order: streak_at_risk > deadline_critical > ci_failure > milestone_near > open_prs > github_drought > open_issues > perfect_day > intention_done > intention_missing > period_start > no_focus_project > weak_day_ahead > best_day_ahead > habit_first_check_in > habit_comeback > pomodoro_last_one > focus_streak_milestone > pomodoro_goal_streak > pomodoro_day_record > pomodoro_goal_reached > deadline_soon > goal_expiry > momentum_decline > project_stale > project_context_switching > streak_recession > habit_consecutive_miss > almost_perfect_day > pomodoro_today_above_avg > momentum_rise > goal_done > goal_streak > month_goal_streak > project_ahead > project_near_completion > project_forecast > personal_best > habit_target_near > intention_streak.
+// Priority order: streak_at_risk > deadline_critical > ci_failure > milestone_near > open_prs > github_drought > open_issues > perfect_day > intention_done > intention_missing > period_start > no_focus_project > weak_day_ahead > best_day_ahead > habit_first_check_in > habit_comeback > pomodoro_last_one > focus_streak_milestone > pomodoro_goal_streak > pomodoro_day_record > pomodoro_week_record > pomodoro_goal_reached > deadline_soon > goal_expiry > momentum_decline > project_stale > project_context_switching > streak_recession > habit_consecutive_miss > almost_perfect_day > pomodoro_today_above_avg > momentum_rise > goal_done > goal_streak > month_goal_streak > project_ahead > project_near_completion > project_forecast > personal_best > habit_target_near > intention_streak.
 export function calcTodayInsight(params: InsightParams): TodayInsight | null {
   const {
     habits, todayStr, nowHour, todayIntentionDate, todayIntentionDone, sessionsToday, sessionGoal, habitsAllDoneDate, projects,
@@ -227,6 +234,7 @@ export function calcTodayInsight(params: InsightParams): TodayInsight | null {
     pomodoroGoalStreak,
     pomodoroSessionBest,
     pomodoroRecentAvg,
+    pomodoroWeekRecord,
     intentionConsecutiveDays,
     todayIsWeakHabitDay,
     todayIsBestHabitDay,
@@ -488,6 +496,15 @@ export function calcTodayInsight(params: InsightParams): TodayInsight | null {
     (sessionGoal == null || sessionGoal === 0 || sessionsToday >= sessionGoal)
   ) {
     return { text: `🍅 오늘 포모도로 신기록! (${sessionsToday}세션)`, level: "success" };
+  }
+
+  // 7.495. Pomodoro weekly record: current ISO-week session total beats the same-length window of the
+  // previous ISO week (Mon–today vs. Mon–same-weekday-last-week).
+  // Placed after pomodoro_day_record (7.49) so a same-day personal best (rarer, more impressive) preempts.
+  // Placed before pomodoro_goal_reached (7.5) so a weekly achievement shows if no single-day record today.
+  // pomodoroWeekRecord is the current-week session total returned by calcPomodoroWeekRecord; falsy = no badge.
+  if (pomodoroWeekRecord !== false && pomodoroWeekRecord !== undefined && pomodoroWeekRecord > 0) {
+    return { text: `🍅 포모도로 주간 신기록! (${pomodoroWeekRecord}세션)`, level: "success" };
   }
 
   // 7.5. Pomodoro goal reached: daily session goal met or exceeded — positive reinforcement.

--- a/src/lib/pomodoro.test.ts
+++ b/src/lib/pomodoro.test.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Unit tests for pomodoro pure helpers — calcTodaySessionCount, updatePomodoroHistory, calcLast14Days, calcSessionWeekTrend, calcSessionCountStr, calcPomodoroBadge, calcFocusStreak, phaseAccent, phaseLabel, sessionGoalPct, formatLifetime, playPhaseDone, calcPomodoroMorningReminder, calcPomodoroEveningReminder, calcPomodoroLifetimeMilestone, calcWeeklyPomodoroReport, calcPomodoroGoalStreak, calcPomodoroRecentAvg
-// ABOUTME: Covers today-count reset/increment, 14-day history upsert, date range derivation, prev-7/cur-7 trend logic, badge string (incl. week sessions 7d·N↑), focus streak, section collapsed badge, phase UI mapping, goal-progress percentage, lifetime format, audio feedback graceful fallback, morning start nudge, evening goal-gap nudge, lifetime milestone crossing, weekly pomodoro session report, goal-streak consecutive past days, and recent rolling average sessions (today excluded)
+// ABOUTME: Unit tests for pomodoro pure helpers — calcTodaySessionCount, updatePomodoroHistory, calcLast14Days, calcSessionWeekTrend, calcSessionCountStr, calcPomodoroBadge, calcFocusStreak, phaseAccent, phaseLabel, sessionGoalPct, formatLifetime, playPhaseDone, calcPomodoroMorningReminder, calcPomodoroEveningReminder, calcPomodoroLifetimeMilestone, calcWeeklyPomodoroReport, calcPomodoroGoalStreak, calcPomodoroRecentAvg, calcPomodoroWeekRecord
+// ABOUTME: Covers today-count reset/increment, 14-day history upsert, date range derivation, prev-7/cur-7 trend logic, badge string (incl. week sessions 7d·N↑), focus streak, section collapsed badge, phase UI mapping, goal-progress percentage, lifetime format, audio feedback graceful fallback, morning start nudge, evening goal-gap nudge, lifetime milestone crossing, weekly pomodoro session report, goal-streak consecutive past days, recent rolling average sessions (today excluded), and week-over-week session record detection
 
 import { describe, it, expect } from "vitest";
-import { calcLast14Days, calcSessionWeekTrend, calcTodaySessionCount, updatePomodoroHistory, calcSessionCountStr, calcPomodoroBadge, calcFocusStreak, phaseAccent, phaseLabel, sessionGoalPct, formatLifetime, playPhaseDone, calcPomodoroMorningReminder, calcPomodoroEveningReminder, calcPomodoroLifetimeMilestone, calcWeeklyPomodoroReport, calcPomodoroGoalStreak, calcPomodoroRecentAvg } from "./pomodoro";
+import { calcLast14Days, calcSessionWeekTrend, calcTodaySessionCount, updatePomodoroHistory, calcSessionCountStr, calcPomodoroBadge, calcFocusStreak, phaseAccent, phaseLabel, sessionGoalPct, formatLifetime, playPhaseDone, calcPomodoroMorningReminder, calcPomodoroEveningReminder, calcPomodoroLifetimeMilestone, calcWeeklyPomodoroReport, calcPomodoroGoalStreak, calcPomodoroRecentAvg, calcPomodoroWeekRecord } from "./pomodoro";
 import { colors } from "../theme";
 import type { PomodoroDay } from "../types";
 
@@ -954,6 +954,128 @@ describe("calcPomodoroRecentAvg", () => {
       { date: "2026-03-14", count: 4 },
     ];
     expect(calcPomodoroRecentAvg(history, TODAY)).toBe(2); // (0+4)/2
+  });
+});
+
+describe("calcPomodoroWeekRecord", () => {
+  // Fixtures anchored to 2026-03-17 (Tuesday).
+  // ISO week: Mon 2026-03-16 – Tue 2026-03-17 (current), Mon 2026-03-09 – Tue 2026-03-10 (prev, same window).
+  const TUESDAY = "2026-03-17";
+
+  it("shouldReturnFalseForEmptyHistory", () => {
+    expect(calcPomodoroWeekRecord([], TUESDAY)).toBe(false);
+  });
+
+  it("shouldReturnFalseWhenNoPrevWeekData", () => {
+    // Only current-week entries — prev window has no data, so no record can be claimed.
+    const history: PomodoroDay[] = [
+      { date: "2026-03-16", count: 3 },
+      { date: "2026-03-17", count: 4 },
+    ];
+    expect(calcPomodoroWeekRecord(history, TUESDAY)).toBe(false);
+  });
+
+  it("shouldReturnFalseWhenCurrentWeekHasNoSessions", () => {
+    // Prev week has sessions; current week total = 0 — no record.
+    const history: PomodoroDay[] = [
+      { date: "2026-03-09", count: 3 },
+      { date: "2026-03-10", count: 2 },
+    ];
+    expect(calcPomodoroWeekRecord(history, TUESDAY)).toBe(false);
+  });
+
+  it("shouldReturnCurrentWeekTotalWhenItExceedsPrevWeek", () => {
+    // Prev Mon-Tue: 3+2=5; current Mon-Tue: 3+4=7 → 7 > 5 → returns 7 (current week total).
+    const history: PomodoroDay[] = [
+      { date: "2026-03-09", count: 3 },
+      { date: "2026-03-10", count: 2 },
+      { date: "2026-03-16", count: 3 },
+      { date: "2026-03-17", count: 4 },
+    ];
+    expect(calcPomodoroWeekRecord(history, TUESDAY)).toBe(7);
+  });
+
+  it("shouldReturnFalseWhenCurrentWeekEqualsPrevWeek", () => {
+    // Equal totals (5 vs 5) do not constitute a record.
+    const history: PomodoroDay[] = [
+      { date: "2026-03-09", count: 3 },
+      { date: "2026-03-10", count: 2 },
+      { date: "2026-03-16", count: 2 },
+      { date: "2026-03-17", count: 3 },
+    ];
+    expect(calcPomodoroWeekRecord(history, TUESDAY)).toBe(false);
+  });
+
+  it("shouldReturnFalseWhenCurrentWeekBelowPrevWeek", () => {
+    // Prev: 4+4=8; current: 2+3=5 → behind, not a record.
+    const history: PomodoroDay[] = [
+      { date: "2026-03-09", count: 4 },
+      { date: "2026-03-10", count: 4 },
+      { date: "2026-03-16", count: 2 },
+      { date: "2026-03-17", count: 3 },
+    ];
+    expect(calcPomodoroWeekRecord(history, TUESDAY)).toBe(false);
+  });
+
+  it("shouldWorkForMondayComparingOnlyOneDay", () => {
+    // today = Monday 2026-03-16; window = Mon only. Prev Mon 2026-03-09: 2 sessions, current: 3 → returns 3.
+    const monday = "2026-03-16";
+    const history: PomodoroDay[] = [
+      { date: "2026-03-09", count: 2 },
+      { date: "2026-03-16", count: 3 },
+    ];
+    expect(calcPomodoroWeekRecord(history, monday)).toBe(3);
+  });
+
+  it("shouldWorkForSundayComparingFullWeek", () => {
+    // today = Sunday 2026-03-15; window = Mon 2026-03-09 through Sun 2026-03-15 (current, total 21),
+    //   Mon 2026-03-02 through Sun 2026-03-08 (prev, total 14). Fits within 14-day history cap.
+    const sunday = "2026-03-15";
+    const history: PomodoroDay[] = [
+      { date: "2026-03-02", count: 2 }, { date: "2026-03-03", count: 2 }, { date: "2026-03-04", count: 2 },
+      { date: "2026-03-05", count: 2 }, { date: "2026-03-06", count: 2 }, { date: "2026-03-07", count: 2 },
+      { date: "2026-03-08", count: 2 }, // prev week: 14 total
+      { date: "2026-03-09", count: 3 }, { date: "2026-03-10", count: 3 }, { date: "2026-03-11", count: 3 },
+      { date: "2026-03-12", count: 3 }, { date: "2026-03-13", count: 3 }, { date: "2026-03-14", count: 3 },
+      { date: "2026-03-15", count: 3 }, // current week: 21 total
+    ];
+    expect(calcPomodoroWeekRecord(history, sunday)).toBe(21); // current week: 7 × 3 = 21
+  });
+
+  it("shouldHandleMonthBoundaryCorrectly", () => {
+    // today = 2026-03-02 (Monday); prev Mon = 2026-02-23. Returns 4 (current Mon sessions).
+    const monday = "2026-03-02";
+    const history: PomodoroDay[] = [
+      { date: "2026-02-23", count: 3 },
+      { date: "2026-03-02", count: 4 },
+    ];
+    expect(calcPomodoroWeekRecord(history, monday)).toBe(4);
+  });
+
+  it("shouldComparePrevWeekUsingOnlyAvailableHistoryEntries", () => {
+    // When some prev-week entries are absent (e.g. evicted by 14-day rolling cap or user inactivity),
+    // only the entries present in history are counted — absent dates contribute 0 to prevWeekTotal.
+    // In this fixture, prev-week Mon (2026-03-09) is absent; only Tue (2026-03-10, 4 sessions) exists.
+    // currentWeekTotal: 5 (Mon 3) + 3 (Tue 2) = but wait — let me set up clearly:
+    // prev window (Mon-Tue): only Tue present → prevWeekTotal = 2.
+    // current window (Mon-Tue): both present → thisWeekTotal = 3+4 = 7 > 2 → returns 7.
+    const history: PomodoroDay[] = [
+      { date: "2026-03-10", count: 2 }, // only Tue of prev week (Mon 2026-03-09 absent)
+      { date: "2026-03-16", count: 3 }, // current Mon
+      { date: "2026-03-17", count: 4 }, // current Tue
+    ];
+    expect(calcPomodoroWeekRecord(history, TUESDAY)).toBe(7); // 7 > 2 (partial prev) → 7
+  });
+
+  it("shouldIgnoreEntriesOutsideBothWindows", () => {
+    // Entry 3 weeks ago should not be counted in either window.
+    // Prev Mon-Tue (2026-03-09, 2026-03-10) both absent → prevWeekTotal=0 → false.
+    const history: PomodoroDay[] = [
+      { date: "2026-02-28", count: 10 }, // 3 weeks ago — not in either window
+      { date: "2026-03-16", count: 5 },  // current Mon
+      { date: "2026-03-17", count: 3 },  // current Tue
+    ];
+    expect(calcPomodoroWeekRecord(history, TUESDAY)).toBe(false);
   });
 });
 

--- a/src/lib/pomodoro.ts
+++ b/src/lib/pomodoro.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Helpers for pomodoro session statistics, phase UI mapping, audio feedback, morning start nudge, evening goal-gap nudge, and lifetime milestone notifications
-// ABOUTME: Covers phase color/label, today-count derivation, 14-day history upsert, date range, week trend, header badge string, focus streak, lifetime format, goal-progress percentage, session-end audio cue, morning reminder, evening reminder, cumulative focus milestone crossing, goal-streak consecutive past days, and recent rolling average sessions (today excluded)
+// ABOUTME: Covers phase color/label, today-count derivation, 14-day history upsert, date range, week trend, header badge string, focus streak, lifetime format, goal-progress percentage, session-end audio cue, morning reminder, evening reminder, cumulative focus milestone crossing, goal-streak consecutive past days, recent rolling average sessions (today excluded), and week-over-week session record detection
 
 import type { PomodoroDay } from "../types";
 import { colors } from "../theme";
@@ -319,6 +319,51 @@ export function calcPomodoroRecentAvg(
   const past = history.filter(d => d.date !== todayStr);
   if (past.length === 0) return 0;
   return past.reduce((sum, d) => sum + d.count, 0) / past.length;
+}
+
+// Returns the current ISO-week session total when it strictly exceeds the previous ISO week's total
+// for the same-length window (Mon–today vs. Mon–same-weekday-last-week), or false when not a record.
+// Returning the current total (rather than a boolean) lets callers display the count in a badge.
+// Comparison is anchored to the same weekday so a Monday-only current week is compared only against
+// the previous Monday — fair at any point in the week, not just at week-end.
+// Uses local-midnight Date arithmetic to avoid timezone shifts; same pattern as calcPomodoroGoalStreak.
+// Returns false when either window has zero sessions (no meaningful baseline to beat).
+// Exported for unit testing; pure function with no side effects.
+export function calcPomodoroWeekRecord(
+  history: PomodoroDay[],
+  todayStr: string,
+): number | false {
+  // Uses local-midnight Date arithmetic (same pattern as calcPomodoroGoalStreak) to avoid UTC shifts.
+  const [yr, mo, day] = todayStr.split("-").map(Number);
+  const today = new Date(yr, mo - 1, day); // local midnight
+  const dayOfWeek = today.getDay(); // 0=Sun, 1=Mon … 6=Sat
+  const daysFromMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1; // ISO: Mon=0 offset
+
+  // Build date sets for current and prev windows (same number of days, Mon–today in each).
+  // Note: prevDates uses only the subset of the previous week that mirrors the current-week window
+  // (e.g. Monday-only on a Monday, Mon–Wed on a Wednesday). This makes the comparison pace-fair.
+  // When prev-week entries are absent from history (evicted by the 14-day rolling cap or user inactivity),
+  // only the available entries are summed — absent dates contribute 0. prevWeekTotal=0 returns false.
+  const currentDates = new Set<string>();
+  const prevDates = new Set<string>();
+  for (let i = 0; i <= daysFromMonday; i++) {
+    const cur = new Date(yr, mo - 1, day - daysFromMonday + i);
+    currentDates.add(`${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, "0")}-${String(cur.getDate()).padStart(2, "0")}`);
+
+    const prev = new Date(yr, mo - 1, day - daysFromMonday + i - 7);
+    prevDates.add(`${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, "0")}-${String(prev.getDate()).padStart(2, "0")}`);
+  }
+
+  let thisWeekTotal = 0;
+  let prevWeekTotal = 0;
+  for (const entry of history) {
+    if (currentDates.has(entry.date)) thisWeekTotal += entry.count;
+    else if (prevDates.has(entry.date)) prevWeekTotal += entry.count;
+  }
+
+  return thisWeekTotal > 0 && prevWeekTotal > 0 && thisWeekTotal > prevWeekTotal
+    ? thisWeekTotal
+    : false;
 }
 
 // Returns the desktop notification body when the daily pomodoro goal has not been reached by evening.


### PR DESCRIPTION
## Summary
- `calcPomodoroWeekRecord(history, todayStr)` 순수 함수 추가: 현재 ISO주 누적 세션이 이전 주 같은 요일 기준 비교 값을 초과하면 해당 세션 수 반환, 아니면 `false`
- `InsightParams.pomodoroWeekRecord?: number | false` 파라미터 추가
- `pomodoro_week_record` 배지 (priority 7.495): `pomodoro_day_record(7.49)` 뒤, `pomodoro_goal_reached(7.5)` 앞에 삽입 — 하루 신기록이 더 특별하므로 먼저 표시
- App.tsx에 `calcPomodoroWeekRecord` 와이어업

## Changes
- `src/lib/pomodoro.ts`: `calcPomodoroWeekRecord` 함수 추가 (split-pattern Date 생성으로 UTC 오프셋 방지)
- `src/lib/pomodoro.test.ts`: 10개 테스트 추가 (월요일/일요일/월경계/부분 이전주 데이터 등)
- `src/lib/insight.ts`: 파라미터 JSDoc + 인사이트 케이스 추가 (`!== false && > 0` 명시적 가드)
- `src/lib/insight.test.ts`: 6개 테스트 추가 (우선순위 검증 포함)
- `src/App.tsx`: `calcPomodoroWeekRecord` import + 와이어업

## 선택 근거
기존 `pomodoroHistory` 14일 데이터로 외부 API 없이 self-contained 구현 가능. Goals(최고의 도구 제공) 부합 — 주간 페이스 모니터링으로 사용자가 momentum을 시각화 가능.

---
_자율 개발 에이전트가 생성한 PR_