### PR TITLE
feat(#41): 섹션 켜기/끄기 커스터마이징 기능 추가

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,288 @@
+// ABOUTME: Integration tests for App component — section visibility via hiddenSections state
+// ABOUTME: Verifies that sections hidden via SettingsPanel are removed from the rendered output
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { invoke as mockInvoke } from "@tauri-apps/api/core";
+
+// ── Tauri API mocks ──────────────────────────────────────
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    setAlwaysOnTop: vi.fn().mockResolvedValue(undefined),
+    listen: vi.fn().mockResolvedValue(() => {}),
+    onMoved: vi.fn().mockResolvedValue(() => {}),
+    setPosition: vi.fn().mockResolvedValue(undefined),
+    setSize: vi.fn().mockResolvedValue(undefined),
+    innerSize: vi.fn().mockResolvedValue({ width: 380, height: 700 }),
+  })),
+  PhysicalPosition: class { constructor(public x: number, public y: number) {} },
+  LogicalSize: class { constructor(public width: number, public height: number) {} },
+}));
+
+vi.mock("@tauri-apps/plugin-notification", () => ({
+  isPermissionGranted: vi.fn().mockResolvedValue(false),
+  requestPermission: vi.fn().mockResolvedValue("denied"),
+  sendNotification: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+}));
+
+import App from "./App";
+
+describe("App section visibility via hiddenSections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should hide the 'streaks' section when it is toggled off in SettingsPanel", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Wait for the app to finish loading — Streaks section must be visible initially
+    await waitFor(() => {
+      expect(screen.getByText("Streaks")).toBeTruthy();
+    });
+
+    // Open settings panel
+    const settingsButton = screen.getByTitle(/설정/i);
+    await user.click(settingsButton);
+
+    // Click the 'streaks' section toggle to hide it
+    const streaksToggle = screen.getByTitle("streaks 섹션 표시/숨기기");
+    await user.click(streaksToggle);
+
+    // The Streaks section label should no longer be visible
+    expect(screen.queryByText("Streaks")).toBeNull();
+  });
+});
+
+describe("moveSection — hidden section boundary bug", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // load_data returns sectionOrder with streaks in position 1
+    // load_settings returns null (defaults used)
+    vi.mocked(mockInvoke).mockImplementation((cmd: string) => {
+      if (cmd === "load_data") {
+        return Promise.resolve({
+          projects: [],
+          habits: [],
+          quotes: [],
+          sectionOrder: ["projects", "streaks", "pomodoro", "direction"],
+        });
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  it("should swap pomodoro with the nearest visible section (projects), not with the hidden streaks section", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Wait for initial load — both Projects and Pomodoro must be visible
+    await waitFor(() => {
+      expect(screen.getByText("Projects")).toBeTruthy();
+    });
+
+    // Hide streaks via SettingsPanel so the visible order becomes:
+    // projects, pomodoro, direction
+    const settingsButton = screen.getByTitle(/설정/i);
+    await user.click(settingsButton);
+
+    const streaksToggle = screen.getByTitle("streaks 섹션 표시/숨기기");
+    await user.click(streaksToggle);
+
+    // Close settings panel so section move buttons become accessible
+    await user.click(settingsButton);
+
+    // Click "위로" (move up) on the Pomodoro section header
+    // At this point the visible order is: projects(idx=0), pomodoro(idx=2), direction(idx=3)
+    // The bug: moveSection uses the raw sectionOrder index, so pomodoro(idx=2) swaps with
+    //          sectionOrder[1] = streaks (hidden), not with projects.
+    const moveUpButtons = screen.getAllByTitle("섹션 위로 이동");
+    // The second "섹션 위로 이동" button belongs to pomodoro (first visible one after projects)
+    await user.click(moveUpButtons[1]);
+
+    // After moving up, save_data must have been called with a sectionOrder where
+    // pomodoro appears BEFORE projects — i.e., streaks must NOT appear between projects and pomodoro.
+    // The correct result is ["pomodoro","projects","streaks","direction"] or equivalent where
+    // pomodoro comes before projects.
+    // The bug produces ["projects","pomodoro","streaks","direction"] — streaks swapped into position 1
+    // but pomodoro stayed at position 2, which is wrong; actually the bug swaps pomodoro & streaks →
+    // ["projects","pomodoro","streaks","direction"], so pomodoro goes to index 1 but streaks to index 2
+    // — visually pomodoro appears to have moved but streaks was shuffled silently.
+    //
+    // The correct behavior: pomodoro should swap with projects (the previous VISIBLE section),
+    // yielding sectionOrder where pomodoro precedes projects in the order.
+    const saveDataCalls = vi.mocked(mockInvoke).mock.calls.filter(
+      ([cmd]) => cmd === "save_data"
+    );
+    const lastSave = saveDataCalls[saveDataCalls.length - 1];
+    const savedOrder = (lastSave[1] as { data: { sectionOrder: string[] } }).data.sectionOrder;
+
+    const pomodoroIdx = savedOrder.indexOf("pomodoro");
+    const projectsIdx = savedOrder.indexOf("projects");
+
+    // pomodoro must come before projects in the saved order (the move-up succeeded past the hidden section)
+    expect(pomodoroIdx).toBeLessThan(projectsIdx);
+  });
+});
+
+describe("hiddenSections — save_data called with hiddenSections on toggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call save_data with hiddenSections when a section is toggled off in SettingsPanel", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Wait for the app to finish loading
+    await waitFor(() => {
+      expect(screen.getByText("Streaks")).toBeTruthy();
+    });
+
+    // Open settings panel
+    const settingsButton = screen.getByTitle(/설정/i);
+    await user.click(settingsButton);
+
+    // Toggle streaks section off
+    const streaksToggle = screen.getByTitle("streaks 섹션 표시/숨기기");
+    await user.click(streaksToggle);
+
+    // save_data must have been called with hiddenSections: ["streaks"]
+    const saveDataCalls = vi.mocked(mockInvoke).mock.calls.filter(
+      ([cmd]) => cmd === "save_data"
+    );
+    expect(saveDataCalls.length).toBeGreaterThan(0);
+    const lastSave = saveDataCalls[saveDataCalls.length - 1];
+    const savedHidden = (lastSave[1] as { data: { hiddenSections?: string[] } }).data.hiddenSections;
+    expect(savedHidden).toContain("streaks");
+  });
+});
+
+describe("arrow buttons — disabled for first/last visible section", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // streaks is first in order; projects is second
+    vi.mocked(mockInvoke).mockImplementation((cmd: string) => {
+      if (cmd === "load_data") {
+        return Promise.resolve({
+          projects: [],
+          habits: [],
+          quotes: [],
+          sectionOrder: ["streaks", "projects", "pomodoro", "direction"],
+        });
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  it("should disable the up button for projects when streaks (first in order) is hidden", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Wait for app load
+    await waitFor(() => {
+      expect(screen.getByText("Projects")).toBeTruthy();
+    });
+
+    // Hide streaks via SettingsPanel — projects becomes the first visible section
+    const settingsButton = screen.getByTitle(/설정/i);
+    await user.click(settingsButton);
+
+    const streaksToggle = screen.getByTitle("streaks 섹션 표시/숨기기");
+    await user.click(streaksToggle);
+
+    // Close settings panel
+    await user.click(settingsButton);
+
+    // The "위로" button for projects (now the first visible section) must be disabled
+    // Bug: idx=1 in the full order, so up is defined and button is enabled
+    const moveUpButtons = screen.getAllByTitle("섹션 위로 이동");
+    // moveUpButtons[0] belongs to projects (the first visible section)
+    expect((moveUpButtons[0] as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("hiddenSections — import syncs UI state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should hide the 'streaks' section in the UI after importing data that contains hiddenSections: ['streaks']", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Wait for the app to finish loading — Streaks must be visible initially
+    await waitFor(() => {
+      expect(screen.getByText("Streaks")).toBeTruthy();
+    });
+
+    // Open settings panel
+    const settingsButton = screen.getByTitle(/설정/i);
+    await user.click(settingsButton);
+
+    // Prepare import JSON that includes hiddenSections: ["streaks"]
+    const importData = JSON.stringify({
+      projects: [],
+      habits: [],
+      quotes: [],
+      hiddenSections: ["streaks"],
+    });
+    const file = new File([importData], "backup.json", { type: "application/json" });
+
+    // Trigger the hidden file input inside SettingsPanel
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(fileInput, file);
+
+    // After import, the Streaks section must be hidden because hiddenSections was imported
+    // BUG: onImport={persist} only calls persist() which calls setData(),
+    //      but setHiddenSections() is never called — so Streaks remains visible.
+    await waitFor(() => {
+      expect(screen.queryByText("Streaks")).toBeNull();
+    });
+  });
+});
+
+describe("hiddenSections — persistence across app restart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should restore hiddenSections after remount when it was persisted in load_data", async () => {
+    // Arrange: load_data returns data that includes hiddenSections: ["streaks"]
+    // This simulates a user who previously hid the streaks section and the value was saved.
+    vi.mocked(mockInvoke).mockImplementation((cmd: string) => {
+      if (cmd === "load_data") {
+        return Promise.resolve({
+          projects: [],
+          habits: [],
+          quotes: [],
+          // hiddenSections persisted from a previous session
+          hiddenSections: ["streaks"],
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const { unmount } = render(<App />);
+
+    // Streaks should NOT appear after load because hiddenSections was persisted
+    await waitFor(() => {
+      // Projects section must be visible to confirm the app has loaded
+      expect(screen.getByText("Projects")).toBeTruthy();
+    });
+
+    // Streaks must be hidden — it was in the persisted hiddenSections list
+    expect(screen.queryByText("Streaks")).toBeNull();
+
+    unmount();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,7 @@ export default function App() {
   const [showQuarterGoalHistory, setShowQuarterGoalHistory] = useState(false);
   const [showYearGoalHistory, setShowYearGoalHistory] = useState(false);
   const { settings, updateSettings, loaded: settingsLoaded } = useSettings();
+  const [hiddenSections, setHiddenSections] = useState<SectionKey[]>([]);
 
   useWindowSync({
     settings,
@@ -147,6 +148,7 @@ export default function App() {
             ...(yearGoalStale ? { yearGoal: undefined, yearGoalDate: undefined, yearGoalDone: undefined } : {}),
           } : saved;
           setData(resolvedData);
+          if (resolvedData.hiddenSections !== undefined) setHiddenSections(resolvedData.hiddenSections);
           if (needsSave) await invoke("save_data", { data: resolvedData });
         }
       } finally {
@@ -155,14 +157,20 @@ export default function App() {
     })();
   }, []);
 
-  const persist = useCallback(async (next: WidgetData) => {
-    setData(next);
-    await invoke("save_data", { data: next });
-  }, []);
-
   // Mirror current data in a ref so interval callbacks always see the latest state (avoids stale closure)
   const dataRef = useRef(data);
   dataRef.current = data;
+  const hiddenSectionsRef = useRef(hiddenSections);
+  hiddenSectionsRef.current = hiddenSections;
+
+  const persist = useCallback(async (next: WidgetData) => {
+    const withHidden: WidgetData = next.hiddenSections !== undefined
+      ? next
+      : { ...next, hiddenSections: hiddenSectionsRef.current };
+    setData(withHidden);
+    await invoke("save_data", { data: withHidden });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const updateHabit = useCallback((i: number, patch: Partial<Habit>) => {
     const snapshot = dataRef.current;
@@ -1645,9 +1653,14 @@ export default function App() {
 
   const moveSection = useCallback((section: SectionKey, dir: -1 | 1) => {
     const snapshot = dataRef.current;
+    const hidden = hiddenSectionsRef.current;
     const order = snapshot.sectionOrder ?? DEFAULT_SECTION_ORDER;
     const i = order.indexOf(section);
-    const j = i + dir;
+    // Find nearest visible section in the given direction
+    let j = i + dir;
+    while (j >= 0 && j < order.length && hidden.includes(order[j])) {
+      j += dir;
+    }
     if (j < 0 || j >= order.length) return;
     const next = [...order];
     [next[i], next[j]] = [next[j], next[i]];
@@ -2199,8 +2212,11 @@ export default function App() {
         />
 
         {(data.sectionOrder ?? DEFAULT_SECTION_ORDER).map((key, idx, order) => {
-          const up = idx > 0 ? () => moveSection(key, -1) : undefined;
-          const dn = idx < order.length - 1 ? () => moveSection(key, 1) : undefined;
+          if (hiddenSections.includes(key)) return null;
+          const visibleOrder = order.filter(k => !hiddenSections.includes(k));
+          const visibleIdx = visibleOrder.indexOf(key);
+          const up = visibleIdx > 0 ? () => moveSection(key, -1) : undefined;
+          const dn = visibleIdx < visibleOrder.length - 1 ? () => moveSection(key, 1) : undefined;
           if (key === "projects") return (
             <Fragment key="projects">
               <SectionLabel accent={themeAccent} collapsed={collapsed.includes("projects")} onToggle={() => toggleSection("projects")} badge={projectsBadge} onMoveUp={up} onMoveDown={dn}>Projects</SectionLabel>
@@ -2703,7 +2719,7 @@ export default function App() {
 
       {/* ── Settings panel ── */}
       {settingsOpen && (
-        <SettingsPanel settings={settings} onUpdate={updateSettings} widgetData={data} onImport={persist} />
+        <SettingsPanel settings={settings} onUpdate={updateSettings} widgetData={data} onImport={(imported) => { if (imported.hiddenSections !== undefined) { setHiddenSections(imported.hiddenSections); hiddenSectionsRef.current = imported.hiddenSections; } persist(imported); }} hiddenSections={hiddenSections} onHiddenSectionsChange={(next) => { setHiddenSections(next); hiddenSectionsRef.current = next; persist({ ...dataRef.current, hiddenSections: next }); }} />
       )}
     </div>
   );

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,0 +1,68 @@
+// ABOUTME: Unit tests for SettingsPanel component — section visibility toggle behavior
+// ABOUTME: Covers hiddenSections on/off toggle UI for each SectionKey
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingsPanel } from "./SettingsPanel";
+import type { WidgetSettings, WidgetData, SectionKey } from "../types";
+
+const baseSettings: WidgetSettings = {
+  position: { x: 0, y: 0 },
+  size: { width: 380, height: 700 },
+  opacity: 1.0,
+  theme: "void",
+};
+
+const baseWidgetData: WidgetData = {
+  projects: [],
+  habits: [],
+  quotes: [],
+};
+
+describe("SettingsPanel section visibility toggles", () => {
+  it("should render a section visibility toggle for the 'projects' section", () => {
+    render(
+      <SettingsPanel
+        settings={baseSettings}
+        onUpdate={vi.fn()}
+        widgetData={baseWidgetData}
+        hiddenSections={[]}
+        onHiddenSectionsChange={vi.fn()}
+      />
+    );
+    expect(screen.getByTitle("projects 섹션 표시/숨기기")).toBeDefined();
+  });
+
+  it("should call onHiddenSectionsChange with the section added when a visible section toggle is clicked", async () => {
+    const user = userEvent.setup();
+    const onHiddenSectionsChange = vi.fn();
+    render(
+      <SettingsPanel
+        settings={baseSettings}
+        onUpdate={vi.fn()}
+        widgetData={baseWidgetData}
+        hiddenSections={[]}
+        onHiddenSectionsChange={onHiddenSectionsChange}
+      />
+    );
+    await user.click(screen.getByTitle("streaks 섹션 표시/숨기기"));
+    expect(onHiddenSectionsChange).toHaveBeenCalledWith(["streaks"]);
+  });
+
+  it("should call onHiddenSectionsChange with the section removed when a hidden section toggle is clicked", async () => {
+    const user = userEvent.setup();
+    const onHiddenSectionsChange = vi.fn();
+    render(
+      <SettingsPanel
+        settings={baseSettings}
+        onUpdate={vi.fn()}
+        widgetData={baseWidgetData}
+        hiddenSections={["streaks"] as SectionKey[]}
+        onHiddenSectionsChange={onHiddenSectionsChange}
+      />
+    );
+    await user.click(screen.getByTitle("streaks 섹션 표시/숨기기"));
+    expect(onHiddenSectionsChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useEffect, useRef, CSSProperties } from "react";
 import { fontSizes, colors, THEMES, ThemeKey } from "../theme";
-import type { WidgetSettings, WidgetData } from "../types";
+import type { WidgetSettings, WidgetData, SectionKey } from "../types";
 import { buildExportBlob, triggerDownload, parseImportedData } from "../lib/dataIO";
 
 type PatStatus = 'idle' | 'testing' | 'ok' | 'error';
@@ -24,11 +24,15 @@ async function testPat(pat: string): Promise<{ status: PatStatus; msg: string }>
   }
 }
 
+const ALL_SECTIONS: SectionKey[] = ["projects", "streaks", "direction", "pomodoro"];
+
 interface SettingsPanelProps {
   settings: WidgetSettings;
   onUpdate: (patch: Partial<WidgetSettings>) => void;
   widgetData?: WidgetData;
   onImport?: (data: WidgetData) => void;
+  hiddenSections?: SectionKey[];
+  onHiddenSectionsChange?: (sections: SectionKey[]) => void;
 }
 
 const row: CSSProperties = {
@@ -45,7 +49,7 @@ const label: CSSProperties = {
   flexShrink: 0,
 };
 
-export function SettingsPanel({ settings, onUpdate, widgetData, onImport }: SettingsPanelProps) {
+export function SettingsPanel({ settings, onUpdate, widgetData, onImport, hiddenSections = [], onHiddenSectionsChange }: SettingsPanelProps) {
   const currentTheme = settings.theme;
   const themeAccent = THEMES[currentTheme].accent;
 
@@ -247,6 +251,40 @@ export function SettingsPanel({ settings, onUpdate, widgetData, onImport }: Sett
                 }}
               >
                 {fmt}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div style={{ ...row, alignItems: "flex-start", flexDirection: "column", gap: 6, paddingTop: 10, borderTop: `1px solid ${colors.borderFaint}` }}>
+        <span style={label}>섹션</span>
+        <div style={{ display: "flex", gap: 4 }}>
+          {ALL_SECTIONS.map(section => {
+            const hidden = hiddenSections.includes(section);
+            return (
+              <button
+                key={section}
+                title={`${section} 섹션 표시/숨기기`}
+                onClick={() => {
+                  if (!onHiddenSectionsChange) return;
+                  if (hidden) {
+                    onHiddenSectionsChange(hiddenSections.filter(s => s !== section));
+                  } else {
+                    onHiddenSectionsChange([...hiddenSections, section]);
+                  }
+                }}
+                style={{
+                  fontSize: fontSizes.xs,
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  background: "transparent",
+                  color: hidden ? colors.textPhantom : themeAccent,
+                  border: `1px solid ${hidden ? colors.borderFaint : themeAccent}`,
+                  cursor: "pointer",
+                }}
+              >
+                {section}
               </button>
             );
           })}

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export interface WidgetData {
   pomodoroHistory?: PomodoroDay[];    // rolling 14-day daily session counts for the 7-day heatmap
   collapsedSections?: SectionKey[];  // section names currently collapsed
   sectionOrder?: SectionKey[];       // display order of sections; absent = default order
+  hiddenSections?: SectionKey[];     // section names currently hidden from view; absent = all visible
   quoteInterval?: number;            // auto-rotation interval in seconds (default 8)
   todayIntention?: string;           // one-line daily intention set by user; absent = not set
   todayIntentionDate?: string;       // YYYY-MM-DD when todayIntention was last set; absent = not tracked


### PR DESCRIPTION
## Summary

- SettingsPanel에 각 섹션(projects, streaks, pomodoro, direction)의 표시/숨기기 토글 UI 추가
- 숨긴 섹션은 렌더링에서 제외되고, 앱 재시작 후에도 설정이 유지됨 (WidgetData.hiddenSections 영속화)
- 섹션 이동(↑↓) 시 숨겨진 섹션을 건너뛰어 visible 섹션 간에만 스왑

## Test plan

- [ ] SettingsPanel에서 섹션 토글 버튼 클릭 시 해당 섹션이 화면에서 사라지는지 확인
- [ ] 앱 재시작 후 숨긴 섹션 설정이 유지되는지 확인
- [ ] 숨겨진 섹션이 있을 때 나머지 섹션의 ↑↓ 이동이 올바르게 동작하는지 확인
- [ ] 데이터 import 시 hiddenSections가 반영되는지 확인

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)