### PR TITLE
test(components): MomentumCalendarCard 엣지케이스 4개 추가 — mid 불투명도·low 불투명도·기본 accent fallback·mid 색상

### DIFF
--- a/src/components/MomentumCalendarCard.test.tsx
+++ b/src/components/MomentumCalendarCard.test.tsx
@@ -189,7 +189,7 @@ describe("MomentumCalendarCard", () => {
       expect(dot.style.background).toBe("rgb(56, 189, 248)");
     });
 
-    it("should not apply accent color to low-tier dot", () => {
+    it("should not apply accent color to low-tier dot — uses statusPaused (#F87171)", () => {
       const accent = "#38BDF8";
       const lowDay = calendarFull.days.find(d => d.tier === "low")!;
       const { container } = render(
@@ -198,7 +198,8 @@ describe("MomentumCalendarCard", () => {
       const titleAttr =
         lowDay.score !== null ? `${lowDay.date} · ${lowDay.score}점` : lowDay.date;
       const dot = container.querySelector(`[title="${titleAttr}"]`) as HTMLElement;
-      expect(dot.style.background).not.toBe("rgb(56, 189, 248)");
+      // low-tier always uses statusPaused regardless of accent: #F87171 → rgb(248, 113, 113)
+      expect(dot.style.background).toBe("rgb(248, 113, 113)");
     });
   });
 
@@ -216,6 +217,44 @@ describe("MomentumCalendarCard", () => {
       const titleAttr = `${highDay.date} · ${highDay.score}점`;
       const dot = container.querySelector(`[title="${titleAttr}"]`) as HTMLElement;
       expect(dot.style.opacity).toBe("0.9");
+    });
+
+    it("should render mid-tier dots with opacity 0.75", () => {
+      const midDay = calendarFull.days.find(d => d.tier === "mid")!;
+      const { container } = render(<MomentumCalendarCard calendar={calendarFull} />);
+      const titleAttr = `${midDay.date} · ${midDay.score}점`;
+      const dot = container.querySelector(`[title="${titleAttr}"]`) as HTMLElement;
+      expect(dot.style.opacity).toBe("0.75");
+    });
+
+    it("should render low-tier dots with opacity 0.6", () => {
+      const lowDay = calendarFull.days.find(d => d.tier === "low")!;
+      const { container } = render(<MomentumCalendarCard calendar={calendarFull} />);
+      const titleAttr = `${lowDay.date} · ${lowDay.score}점`;
+      const dot = container.querySelector(`[title="${titleAttr}"]`) as HTMLElement;
+      expect(dot.style.opacity).toBe("0.6");
+    });
+  });
+
+  describe("default accent fallback", () => {
+    it("should use statusActive (#4ADE80) for high-tier when accent is undefined", () => {
+      const highDay = calendarFull.days.find(d => d.tier === "high")!;
+      const { container } = render(<MomentumCalendarCard calendar={calendarFull} />);
+      const titleAttr = `${highDay.date} · ${highDay.score}점`;
+      const dot = container.querySelector(`[title="${titleAttr}"]`) as HTMLElement;
+      // accent ?? colors.statusActive: #4ADE80 → rgb(74, 222, 128)
+      expect(dot.style.background).toBe("rgb(74, 222, 128)");
+    });
+  });
+
+  describe("dot color by tier", () => {
+    it("should apply statusProgress (#FBBF24) color to mid-tier dot regardless of accent", () => {
+      const midDay = calendarFull.days.find(d => d.tier === "mid")!;
+      const { container } = render(<MomentumCalendarCard calendar={calendarFull} accent="#38BDF8" />);
+      const titleAttr = `${midDay.date} · ${midDay.score}점`;
+      const dot = container.querySelector(`[title="${titleAttr}"]`) as HTMLElement;
+      // mid-tier always uses statusProgress independent of accent: #FBBF24 → rgb(251, 191, 36)
+      expect(dot.style.background).toBe("rgb(251, 191, 36)");
     });
   });
 });


### PR DESCRIPTION
## Summary
- `dotOpacity()` mid-tier(0.75), low-tier(0.6) 브랜치 positive assertion으로 검증
- `dotColor()` accent 미전달 시 `colors.statusActive` fallback 검증 (`describe("default accent fallback")`)
- mid-tier 도트 색상이 accent 여부와 무관하게 `colors.statusProgress` 사용 검증 (`describe("dot color by tier")`)
- 기존 low-tier `not.toBe` 부정 assertion → `toBe("rgb(248, 113, 113)")` positive assertion으로 교체

## Changes
- `src/components/MomentumCalendarCard.test.tsx`: 4개 신규 테스트 + 기존 `not.toBe` 1건 교체 (20 tests, 16 → 20)

## 선택 근거
`dotOpacity()`와 `dotColor()`의 미커버 브랜치(mid/low tier)가 기존 테스트에서 검증되지 않아 신뢰도 공백이 있었음

---
_자율 개발 에이전트가 생성한 PR_